### PR TITLE
Task comments: reply threading + show reply target

### DIFF
--- a/backend/alembic/versions/9d3d9b9c1a23_add_reply_to_task_comments.py
+++ b/backend/alembic/versions/9d3d9b9c1a23_add_reply_to_task_comments.py
@@ -1,0 +1,32 @@
+"""add reply_to_comment_id to task_comments
+
+Revision ID: 9d3d9b9c1a23
+Revises: 157587037601
+Create Date: 2026-02-02 08:15:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "9d3d9b9c1a23"
+down_revision = "157587037601"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("task_comments", sa.Column("reply_to_comment_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_task_comments_reply_to_comment_id",
+        "task_comments",
+        "task_comments",
+        ["reply_to_comment_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_task_comments_reply_to_comment_id", "task_comments", type_="foreignkey")
+    op.drop_column("task_comments", "reply_to_comment_id")

--- a/backend/app/models/work.py
+++ b/backend/app/models/work.py
@@ -30,5 +30,9 @@ class TaskComment(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     task_id: int = Field(foreign_key="tasks.id", index=True)
     author_employee_id: int | None = Field(default=None, foreign_key="employees.id")
+
+    # Optional reply threading
+    reply_to_comment_id: int | None = Field(default=None, foreign_key="task_comments.id")
+
     body: str
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/schemas/work.py
+++ b/backend/app/schemas/work.py
@@ -24,4 +24,5 @@ class TaskUpdate(SQLModel):
 class TaskCommentCreate(SQLModel):
     task_id: int
     author_employee_id: int | None = None
+    reply_to_comment_id: int | None = None
     body: str


### PR DESCRIPTION
Implements Task #16.\n\nBackend:\n- Add TaskComment.reply_to_comment_id + validation (must exist and match task)\n- Alembic migration to add column + FK\n\nFrontend:\n- Add Reply button per comment\n- Composer shows 'Replying to …' context + cancel\n- Renders reply target snippet in thread\n\nLint: frontend npm run lint\n\nNote: I patched generated types for reply_to_comment_id; can be regenerated with npm run api:gen after backend deploy.