### PR TITLE
docs: add active development caution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OpenClaw Mission Control
 
+[![CI](https://github.com/abhi1693/openclaw-mission-control/actions/workflows/ci.yml/badge.svg)](https://github.com/abhi1693/openclaw-mission-control/actions/workflows/ci.yml)
+
+
 Web UI + API for operating OpenClaw: managing boards, tasks, agents, approvals, and gateway connections.
 
 ## Active development


### PR DESCRIPTION
Adds a short “Active development” note near the top of the root README to set expectations (breaking changes possible) and invite issues/PRs.

Commits:
- start: f03fe837cd4edbc0475fbed1b9ce971ac1c3368e
- end: HEAD