### PR TITLE
docs: add Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,7 @@ Adjust ports in `.env` (copied from `.env.example`):
 - `BACKEND_PORT`
 - `POSTGRES_PORT`
 - `REDIS_PORT`
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=abhi1693/openclaw-mission-control&type=date&legend=top-left)](https://www.star-history.com/#abhi1693/openclaw-mission-control&type=date&legend=top-left)


### PR DESCRIPTION
Appends a Star History chart section to the end of the root README.

Commits:
- start: d4e5e86a2059d73a0462679685d305972465d9f6
- end: HEAD