### PR TITLE
test(e2e): remove auth bypass and sign in via Clerk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,22 @@ jobs:
           make frontend-test
           make frontend-build
 
+      - name: Run Cypress E2E (real Clerk login; no bypass)
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: frontend
+          # next start requires a build output
+          start: npm run start -- --port 3000
+          wait-on: http://localhost:3000/activity
+          wait-on-timeout: 180
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_JWKS_URL: ${{ vars.CLERK_JWKS_URL }}
+          # Optional: if the app uses this at runtime
+          NEXT_PUBLIC_API_URL: http://localhost:8000
+
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:3000",
+    supportFile: false,
+    video: false,
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run --passWithNoTests --coverage",
     "test:watch": "vitest",
     "dev:lan": "next dev --hostname 0.0.0.0 --port 3000",
-    "api:gen": "orval --config ./orval.config.ts"
+    "api:gen": "orval --config ./orval.config.ts",
+    "e2e": "cypress run"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.1",

--- a/frontend/src/auth/clerk.tsx
+++ b/frontend/src/auth/clerk.tsx
@@ -19,29 +19,20 @@ import type { ComponentProps } from "react";
 
 import { isLikelyValidClerkPublishableKey } from "@/auth/clerkKey";
 
-function isE2EAuthBypassEnabled(): boolean {
-  // Used only for Cypress E2E to keep tests secretless and deterministic.
-  // When enabled, we treat the user as signed in and skip Clerk entirely.
-  return process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS === "1";
-}
-
 export function isClerkEnabled(): boolean {
   // IMPORTANT: keep this in sync with AuthProvider; otherwise components like
   // <SignedOut/> may render without a <ClerkProvider/> and crash during prerender.
-  if (isE2EAuthBypassEnabled()) return false;
   return isLikelyValidClerkPublishableKey(
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
   );
 }
 
 export function SignedIn(props: { children: ReactNode }) {
-  if (isE2EAuthBypassEnabled()) return <>{props.children}</>;
   if (!isClerkEnabled()) return null;
   return <ClerkSignedIn>{props.children}</ClerkSignedIn>;
 }
 
 export function SignedOut(props: { children: ReactNode }) {
-  if (isE2EAuthBypassEnabled()) return null;
   if (!isClerkEnabled()) return <>{props.children}</>;
   return <ClerkSignedOut>{props.children}</ClerkSignedOut>;
 }
@@ -67,15 +58,6 @@ export function useUser() {
 }
 
 export function useAuth() {
-  if (isE2EAuthBypassEnabled()) {
-    return {
-      isLoaded: true,
-      isSignedIn: true,
-      userId: "e2e-user",
-      sessionId: "e2e-session",
-      getToken: async () => "e2e-token",
-    } as const;
-  }
   if (!isClerkEnabled()) {
     return {
       isLoaded: true,


### PR DESCRIPTION
Removes the Cypress auth-bypass flag and updates E2E to perform a real Clerk sign-in (email + OTP). Also wires a Cypress E2E run into CI with Clerk keys from repo secrets/vars.

Start commit: e04a0010e0806c07692d4640f4d56f26195cdd39
End commit: 4cfc7d2dd18a5d6ad3cc4a559d7e26a1005320fd