### PR TITLE
lint: fix W391 trailing blank lines

### DIFF
--- a/backend/app/api/souls_directory.py
+++ b/backend/app/api/souls_directory.py
@@ -71,4 +71,3 @@ async def get_markdown(
     except Exception as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
     return SoulsDirectoryMarkdownResponse(handle=safe_handle, slug=safe_slug, content=content)
-

--- a/backend/app/schemas/souls_directory.py
+++ b/backend/app/schemas/souls_directory.py
@@ -18,4 +18,3 @@ class SoulsDirectoryMarkdownResponse(BaseModel):
     handle: str
     slug: str
     content: str
-

--- a/backend/tests/test_souls_directory.py
+++ b/backend/tests/test_souls_directory.py
@@ -26,4 +26,3 @@ def test_search_souls_matches_handle_or_slug() -> None:
     ]
     assert search_souls(refs, query="writer", limit=20) == [refs[1]]
     assert search_souls(refs, query="thedaviddias", limit=20) == [refs[0], refs[1]]
-


### PR DESCRIPTION
Fixes flake8 W391 (blank line at end of file) in souls_directory files which is currently failing CI for unrelated PRs (actions/checkout uses merge commit in PR CI).