### PR TITLE
Fix vitest matcher typings in frontend tests

### DIFF
--- a/frontend/src/components/activity/ActivityFeed.test.tsx
+++ b/frontend/src/components/activity/ActivityFeed.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
 
 import { ActivityFeed } from "./ActivityFeed";
 

--- a/frontend/src/lib/backoff.test.ts
+++ b/frontend/src/lib/backoff.test.ts
@@ -1,4 +1,6 @@
 import { createExponentialBackoff } from "./backoff";
+import { describe, expect, it, vi } from "vitest";
+
 
 describe("createExponentialBackoff", () => {
   it("uses default options", () => {


### PR DESCRIPTION
Fixes CI typecheck failure seen on PR #48 by explicitly importing Vitest globals in the new test files.

- Ensures `expect(...).toBe*` + `jest-dom` matchers are typed even if global type augmentation is not picked up.

Refs: #48