### PR TITLE
fix: make frontend test types pass in CI

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["vitest/globals", "@testing-library/jest-dom/vitest"]
+    "types": ["vitest", "vitest/globals", "@testing-library/jest-dom/vitest"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Fixes TS typecheck failures in frontend tests by ensuring vitest expect + jest-dom matcher types are included in tsconfig.