### PR TITLE
ci: fix e2e job condition (hashFiles not allowed at job level)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,6 @@ jobs:
             frontend/coverage/**
 
   e2e:
-    # Run only when a Cypress suite exists in the repo.
-    if: ${{ hashFiles('**/cypress.config.*') != '' }}
     runs-on: ubuntu-latest
     needs: [check]
 


### PR DESCRIPTION
Fix failing CI run on master: job-level `if` conditions cannot use `hashFiles()` (it’s only available in runner/step context), which can cause the workflow run to fail before creating any jobs.

Change:
- Remove the job-level hashFiles() guard; e2e job will run normally.