### PR TITLE
ci: fix workflow parse error (remove hashFiles job-if)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,9 @@ jobs:
             frontend/coverage/**
 
   e2e:
-    # Run only when a Cypress suite exists in the repo.
-    if: ${{ hashFiles('**/cypress.config.*') != '' }}
+    # E2E suite (Cypress).
+    # NOTE: avoid using hashFiles() in job-level if; it can break workflow parsing.
+
     runs-on: ubuntu-latest
     needs: [check]
 


### PR DESCRIPTION
Fixes failing Actions run https://github.com/abhi1693/openclaw-mission-control/actions/runs/21802575493\n\nHypothesis:  in a job-level  can cause GitHub to reject the workflow (0 jobs created). This change removes that job-level condition.