### PR TITLE
ci: fix workflow-file failure on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,9 @@ jobs:
             frontend/coverage/**
 
   e2e:
-    # Run only when a Cypress suite exists in the repo.
-    if: ${{ hashFiles('**/cypress.config.*') != '' }}
+    # NOTE: We intentionally do not gate this job with hashFiles() at the job level.
+    # Some GitHub runners treat that as a workflow-file parse/eval error (no jobs created).
+    # If we ever need conditional E2E again, do it after checkout in a step.
     runs-on: ubuntu-latest
     needs: [check]
 


### PR DESCRIPTION
Master CI run 21802575493 failed with: 'This run likely failed because of a workflow file issue' and created 0 jobs.\n\nSuspect: job-level if using hashFiles() on e2e job. Remove the gate and leave a comment; if we need conditional E2E, do it after checkout in a step.