### PR TITLE
ci: fix workflow parse error (hashFiles in job if)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect Cypress config
+        id: cypress
+        shell: bash
+        run: |
+          if find . -maxdepth 4 -name 'cypress.config.*' -print -quit | grep -q .; then
+            echo "has_cypress=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_cypress=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -85,8 +95,7 @@ jobs:
             frontend/coverage/**
 
   e2e:
-    # Run only when a Cypress suite exists in the repo.
-    if: ${{ hashFiles('**/cypress.config.*') != '' }}
+    # E2E job is a no-op when Cypress isn't present.
     runs-on: ubuntu-latest
     needs: [check]
 
@@ -95,6 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node
+        if: ${{ steps.cypress.outputs.has_cypress == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -102,9 +112,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: ${{ steps.cypress.outputs.has_cypress == 'true' }}
         run: make frontend-sync
 
       - name: Start frontend (dev server)
+        if: ${{ steps.cypress.outputs.has_cypress == 'true' }}
         env:
           NEXT_PUBLIC_API_URL: "http://localhost:3000"
           NEXT_TELEMETRY_DISABLED: "1"
@@ -122,6 +134,7 @@ jobs:
           exit 1
 
       - name: Run Cypress E2E
+        if: ${{ steps.cypress.outputs.has_cypress == 'true' }}
         env:
           NEXT_PUBLIC_API_URL: "http://localhost:3000"
           NEXT_TELEMETRY_DISABLED: "1"
@@ -138,7 +151,7 @@ jobs:
           npm run e2e -- --browser chrome
 
       - name: Upload Cypress artifacts
-        if: failure()
+        if: ${{ steps.cypress.outputs.has_cypress == 'true' && failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: cypress-artifacts


### PR DESCRIPTION
Fixes CI workflow parse error causing Actions run to fail with no jobs. Replaces job-level hashFiles guard with a Detect Cypress step + step-level gating.