### PR TITLE
ci: fix invalid workflow run (remove job-level hashFiles guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,7 @@ jobs:
             frontend/coverage/**
 
   e2e:
-    # Run only when a Cypress suite exists in the repo.
-    if: ${{ hashFiles('**/cypress.config.*') != '' }}
+    # E2E suite (Cypress)
     runs-on: ubuntu-latest
     needs: [check]
 


### PR DESCRIPTION
Fixes workflow run https://github.com/abhi1693/openclaw-mission-control/actions/runs/21802575493 failing with "workflow file issue" (0 jobs created).

Change:
- Remove the job-level `if: ${{ hashFiles(...) }}` guard on the `e2e` job.

Rationale:
- `hashFiles()` can cause workflow parsing/evaluation failures at the job level (GitHub reports a workflow file issue and doesn't even create jobs/logs), so the CI run fails immediately.

Start commit: df552a7286588b175eea0ceeea7ffc16563f9be2
End commit: 8e44117e0d4d31c95ea76513ba8b697f2ceac8b2
