### PR TITLE
docs: strengthen ops/runbooks hub

### DIFF
--- a/docs/09-ops-runbooks.md
+++ b/docs/09-ops-runbooks.md
@@ -1,33 +1,42 @@
 # Ops / runbooks
 
+This is the operator entrypoint for Mission Control. It links to the deeper deployment and troubleshooting guides and provides a short “first 30 minutes” checklist for incidents.
+
 ## Deep dives
 
 - [Deployment](deployment/README.md)
 - [Production](production/README.md)
 - [Troubleshooting](troubleshooting/README.md)
 
-This page is the operator entrypoint. It points to the existing deep-dive runbooks and adds a short “first 30 minutes” checklist.
+## Safety callouts (read first)
+
+- **Data loss:** `docker compose down -v` deletes the Postgres volume. Use only when you are intentionally resetting the environment.
+- **Migration risk:** `DB_AUTO_MIGRATE=true` applies Alembic migrations on backend startup.
+  - This is convenient in dev.
+  - In production, prefer running migrations as an explicit step and keeping auto-migrate off.
 
 ## First 30 minutes (incident checklist)
 
 1. **Confirm impact**
    - What’s broken: UI, API, auth, or gateway integration?
-   - All users or a subset?
+   - All users or a subset? A single board/org or all boards?
 
 2. **Check service health**
    - Backend: `/healthz` and `/readyz`
-   - Frontend: can it load? does it reach the API?
+   - Frontend: does it load and reach the API?
 
-3. **Check auth (Clerk)**
-   - Frontend: did Clerk get enabled unintentionally? (publishable key set)
-   - Backend: is `CLERK_SECRET_KEY` configured correctly?
+3. **Check configuration drift**
+   - `NEXT_PUBLIC_API_URL`: browser-reachable backend URL
+   - `DATABASE_URL`: backend can reach Postgres
+   - `CORS_ORIGINS`: includes the frontend origin
 
-4. **Check DB connectivity**
-   - Can backend connect to Postgres (`DATABASE_URL`)?
+4. **Check auth (Clerk)**
+   - Frontend: Clerk keys are present and correct
+   - Backend: `CLERK_SECRET_KEY` is present and correct
 
 5. **Check logs**
-   - Backend logs for 5xx spikes or auth failures.
-   - Frontend logs for API URL/proxy misconfig.
+   - Backend logs for auth failures and 5xx spikes.
+   - Frontend logs for API URL/proxy issues.
 
 6. **Stabilize**
    - Roll back the last change if you can.


### PR DESCRIPTION
Updates  to serve as a clearer operator hub: adds prominent safety callouts (data loss + migration risk), keeps a concise incident checklist, and links to the existing deep-dive ops docs.