### PR TITLE
docs: add Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ make check
 ## License
 
 This project is licensed under the MIT License. See [`LICENSE`](./LICENSE).
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=abhi1693/openclaw-mission-control&type=date&legend=top-left)](https://www.star-history.com/#abhi1693/openclaw-mission-control&type=date&legend=top-left)


### PR DESCRIPTION
This PR appends the Star History section to the end of `README.md` (docs-only, minimal diff).

Exact snippet added:
```md
## Star History

[![Star History Chart](https://api.star-history.com/svg?repos=abhi1693/openclaw-mission-control&type=date&legend=top-left)](https://www.star-history.com/#abhi1693/openclaw-mission-control&type=date&legend=top-left)
```

Preview: the new section renders a Star History chart badge linking to star-history.com.