### PR TITLE
perf(db): add composite indexes for task listing

### DIFF
--- a/backend/migrations/versions/b4338be78eec_add_composite_indexes_for_task_listing.py
+++ b/backend/migrations/versions/b4338be78eec_add_composite_indexes_for_task_listing.py
@@ -1,0 +1,45 @@
+"""add composite indexes for task listing
+
+Revision ID: b4338be78eec
+Revises: f4d2b649e93a
+Create Date: 2026-02-12 07:54:27.450391
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4338be78eec'
+down_revision = 'f4d2b649e93a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Task list endpoints filter primarily by board_id, optionally by status
+    # and assigned_agent_id, and always order by created_at (desc in code).
+    # These composite btree indexes allow fast backward scans with LIMIT.
+    op.create_index(
+        "ix_tasks_board_id_created_at",
+        "tasks",
+        ["board_id", "created_at"],
+    )
+    op.create_index(
+        "ix_tasks_board_id_status_created_at",
+        "tasks",
+        ["board_id", "status", "created_at"],
+    )
+    op.create_index(
+        "ix_tasks_board_id_assigned_agent_id_created_at",
+        "tasks",
+        ["board_id", "assigned_agent_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tasks_board_id_assigned_agent_id_created_at", table_name="tasks")
+    op.drop_index("ix_tasks_board_id_status_created_at", table_name="tasks")
+    op.drop_index("ix_tasks_board_id_created_at", table_name="tasks")


### PR DESCRIPTION
## Summary
Adds composite btree indexes on `tasks` to speed up the most common task list queries (board-scoped lists ordered by recency).

## Indexes added
- `tasks(board_id, created_at)`
- `tasks(board_id, status, created_at)`
- `tasks(board_id, assigned_agent_id, created_at)`

## Evidence
### Query: board task list
```sql
SELECT *
FROM tasks
WHERE board_id = $1
ORDER BY created_at DESC
LIMIT 50;
```

**Before** (existing single-column indexes): Bitmap Heap Scan + top-N sort
- ~42.5 ms (local Postgres, 200k tasks in one board)

**After** (this PR): Index Scan Backward using `ix_tasks_board_id_created_at`
- ~0.28 ms (same setup)

### Query: status-filtered task list (selective)
```sql
SELECT *
FROM tasks
WHERE board_id = $1 AND status = 'inbox'
ORDER BY created_at DESC
LIMIT 50;
```
- Uses `ix_tasks_board_id_status_created_at` (Index Scan Backward).

## Notes
- No query logic changes; migration-only.

## Audit / hygiene confirmation (2026-02-12)
- Branch `perf/task-list-indexes` is based on `origin/master` with a single relevant commit.