### PR TITLE
perf(db): index board memory listing + task comments

### DIFF
--- a/backend/migrations/versions/99cd6df95f85_add_indexes_for_board_memory_task_.py
+++ b/backend/migrations/versions/99cd6df95f85_add_indexes_for_board_memory_task_.py
@@ -1,0 +1,48 @@
+"""add indexes for board memory + task comments
+
+Revision ID: 99cd6df95f85
+Revises: f4d2b649e93a
+Create Date: 2026-02-12 08:13:19.786621
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '99cd6df95f85'
+down_revision = 'f4d2b649e93a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Board memory lists filter on (board_id, is_chat) and order by created_at desc.
+    op.create_index(
+        "ix_board_memory_board_id_is_chat_created_at",
+        "board_memory",
+        ["board_id", "is_chat", "created_at"],
+    )
+
+    # Task comments are stored as ActivityEvent rows with event_type='task.comment'.
+    # Listing comments uses task_id + created_at ordering, so a partial composite index
+    # avoids scanning other activity rows.
+    op.create_index(
+        "ix_activity_events_task_comment_task_id_created_at",
+        "activity_events",
+        ["task_id", "created_at"],
+        postgresql_where=sa.text("event_type = 'task.comment'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_activity_events_task_comment_task_id_created_at",
+        table_name="activity_events",
+    )
+    op.drop_index(
+        "ix_board_memory_board_id_is_chat_created_at",
+        table_name="board_memory",
+    )


### PR DESCRIPTION
## Summary
Adds supporting DB indexes for two frequent feed-style queries:
- Board memory listing (filter by board + is_chat, order by created_at desc)
- Task comment history (stored as `activity_events` rows with `event_type='task.comment'`)

## Indexes added
- `board_memory(board_id, is_chat, created_at)`
- Partial index for comments:
  - `activity_events(task_id, created_at) WHERE event_type = 'task.comment'`

## Evidence
### Query shapes (from code)
#### Board memory listing
```sql
SELECT *
FROM board_memory
WHERE board_id = $1 AND is_chat = $2
ORDER BY created_at DESC
LIMIT $3;
```

#### Task comments listing
```sql
SELECT *
FROM activity_events
WHERE task_id = $1 AND event_type = 'task.comment'
ORDER BY created_at DESC
LIMIT $2;
```

### Expected plan impact
- These composite indexes allow the planner to use an index scan (often backward) matching the filter + order, avoiding a sort and minimizing heap reads under LIMIT.

## Notes
- No query logic changes; migration-only.

## Audit / hygiene confirmation (2026-02-12)
- Branch `perf/memory-comment-indexes` is based on `origin/master` with a single relevant commit.