### PR TITLE
fix(frontend): mobile-friendly Agents table

### DIFF
--- a/frontend/src/components/tables/DataTable.tsx
+++ b/frontend/src/components/tables/DataTable.tsx
@@ -88,7 +88,7 @@ export function DataTable<TData>({
     (table.getVisibleLeafColumns().length || 1) + (hasRowActions ? 1 : 0);
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-hidden sm:overflow-x-auto">
       <table className={tableClassName}>
         <thead
           className={


### PR DESCRIPTION
Mobile readiness tweak: prevent DataTable from forcing horizontal scrolling on small screens (keeps overflow-x-auto on sm+). This improves Agents/presence page usability without altering data.