### PR TITLE
Meta: PR hygiene template + branching guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Task / context
+- Mission Control task: <link or id>
+- Why: <what problem this PR solves>
+
+## Scope
+- <bullet 1>
+- <bullet 2>
+
+### Out of scope
+- <explicitly list what is NOT included>
+
+## Evidence / validation
+- [ ] `make check` (or explain what you ran instead)
+- [ ] E2E (if applicable): <cypress run / screenshots>
+- Logs/links:
+  - <link to CI run>
+
+## Screenshots (UI changes)
+| Desktop | Mobile |
+| --- | --- |
+| <img src="..." width="600" /> | <img src="..." width="300" /> |
+
+## Docs impact
+- [ ] No user/operator docs changes required
+- [ ] Docs updated: <paths/links>
+
+## Risk / rollout notes
+- Risk level: low / medium / high
+- Rollback plan (if needed): <steps>
+
+## Checklist
+- [ ] Branch created from `origin/master` (no unrelated commits)
+- [ ] PR is focused (one theme)
+- [ ] No secrets in code/logs/docs
+- [ ] If API/behavior changes: docs updated (OpenAPI + `docs/reference/api.md`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,20 @@ When opening an issue, please include:
 
 ## Pull requests
 
+### Branching hygiene (required)
+
+Create feature branches from the latest `origin/master` to avoid unrelated commits in PRs:
+
+```bash
+git fetch origin
+git checkout master
+git reset --hard origin/master
+git checkout -b <branch-name>
+```
+
+If you accidentally based your branch off another feature branch, fix it by cherry-picking the intended commits onto a clean branch and force-pushing the corrected branch (or opening a new PR).
+
+
 ### Expectations
 
 - Keep PRs **small and focused** when possible.


### PR DESCRIPTION
## Summary
Adds a PR template and lightweight branching hygiene guidance to prevent unrelated commits and improve PR body consistency.

## What changed
- Added `.github/pull_request_template.md`.
- Updated `CONTRIBUTING.md` with branching guidance (branch from `origin/master`, keep PRs task-scoped).

## Audit (requested)
- Confirmed this PR is clean:
  - Base: `master`
  - Commits: 1 (`meta: add PR template and branching hygiene guidance`)
  - Files: 2 (`.github/pull_request_template.md`, `CONTRIBUTING.md`)

## Validation
- Docs/meta changes only.
