### PR TITLE
test(frontend): add UserMenu RTL coverage (batch 1)

### DIFF
--- a/frontend/src/components/organisms/UserMenu.test.tsx
+++ b/frontend/src/components/organisms/UserMenu.test.tsx
@@ -4,7 +4,7 @@ import type {
   PropsWithChildren,
   ReactNode,
 } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -53,6 +53,9 @@ describe("UserMenu", () => {
     clearLocalAuthTokenMock.mockReset();
     isLocalAuthModeMock.mockReset();
   });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
   it("renders and opens local-mode menu actions", async () => {
     const user = userEvent.setup();
@@ -91,6 +94,5 @@ describe("UserMenu", () => {
 
     expect(clearLocalAuthTokenMock).toHaveBeenCalledTimes(1);
     expect(reloadSpy).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Summary
- add `UserMenu.test.tsx` coverage for local-mode menu open/actions
- mock `next/image`, `next/link`, and auth/localAuth boundaries

## Validation
- `cd frontend && npm test --silent`
- result: 15 files, 51 tests passed
