### PR TITLE
Fix installer CI: merge Alembic heads to unblock DB_AUTO_MIGRATE

### DIFF
--- a/backend/migrations/versions/2a4fe0f6df5b_merge_heads_after_task_custom_fields.py
+++ b/backend/migrations/versions/2a4fe0f6df5b_merge_heads_after_task_custom_fields.py
@@ -1,0 +1,26 @@
+"""Merge heads after task custom fields.
+
+Revision ID: 2a4fe0f6df5b
+Revises: b6f4c7d9e1a2, d3ca36cf31a1
+Create Date: 2026-02-13 21:43:07
+
+"""
+
+from __future__ import annotations
+
+
+# revision identifiers, used by Alembic.
+revision = "2a4fe0f6df5b"
+down_revision = ("b6f4c7d9e1a2", "d3ca36cf31a1")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge heads."""
+    pass
+
+
+def downgrade() -> None:
+    """Unmerge heads."""
+    pass


### PR DESCRIPTION
Root cause: backend container failed during startup migrations with **MultipleHeads** (b6f4c7d9e1a2, d3ca36cf31a1).

This adds a no-op merge migration to unify heads so `alembic upgrade head` works again, which unblocks installer docker-mode healthz checks.

Evidence:
- CI run: https://github.com/abhi1693/openclaw-mission-control/actions/runs/22003374686 (installer job 63581567783)
- Error: `alembic.script.revision.MultipleHeads: Multiple heads ... b6f4c7d9e1a2, d3ca36cf31a1`

Local verification:
- `docker compose up` with BACKEND_PORT=18000 + DB_AUTO_MIGRATE=true → `curl http://127.0.0.1:18000/healthz` OK after ~8s.