### PR TITLE
Add new agent emoji options and sort alphabetically

### DIFF
--- a/frontend/src/app/agents/[agentId]/edit/page.tsx
+++ b/frontend/src/app/agents/[agentId]/edit/page.tsx
@@ -41,15 +41,25 @@ type IdentityProfile = {
 
 const EMOJI_OPTIONS = [
   { value: ":gear:", label: "Gear", glyph: "⚙️" },
-  { value: ":sparkles:", label: "Sparkles", glyph: "✨" },
-  { value: ":rocket:", label: "Rocket", glyph: "🚀" },
-  { value: ":megaphone:", label: "Megaphone", glyph: "📣" },
+  { value: ":alarm_clock:", label: "Alarm Clock", glyph: "⏰" },
+  { value: ":art:", label: "Art", glyph: "🎨" },
+  { value: ":brain:", label: "Brain", glyph: "🧠" },
+  { value: ":wrench:", label: "Builder", glyph: "🔧" },
+  { value: ":dart:", label: "Bullseye", glyph: "🎯" },
+  { value: ":computer:", label: "Computer", glyph: "💻" },
   { value: ":chart_with_upwards_trend:", label: "Growth", glyph: "📈" },
   { value: ":bulb:", label: "Idea", glyph: "💡" },
-  { value: ":wrench:", label: "Builder", glyph: "🔧" },
-  { value: ":shield:", label: "Shield", glyph: "🛡️" },
+  { value: ":zap:", label: "Lightning", glyph: "⚡" },
+  { value: ":lock:", label: "Lock", glyph: "🔒" },
+  { value: ":mailbox:", label: "Mailbox", glyph: "📬" },
+  { value: ":megaphone:", label: "Megaphone", glyph: "📣" },
   { value: ":memo:", label: "Notes", glyph: "📝" },
-  { value: ":brain:", label: "Brain", glyph: "🧠" },
+  { value: ":owl:", label: "Owl", glyph: "🦉" },
+  { value: ":robot:", label: "Robot", glyph: "🤖" },
+  { value: ":rocket:", label: "Rocket", glyph: "🚀" },
+  { value: ":mag:", label: "Search", glyph: "🔍" },
+  { value: ":shield:", label: "Shield", glyph: "🛡️" },
+  { value: ":sparkles:", label: "Sparkles", glyph: "✨" },
 ];
 
 const getBoardOptions = (boards: BoardRead[]): SearchableSelectOption[] =>

--- a/frontend/src/app/agents/new/page.tsx
+++ b/frontend/src/app/agents/new/page.tsx
@@ -38,15 +38,25 @@ type IdentityProfile = {
 
 const EMOJI_OPTIONS = [
   { value: ":gear:", label: "Gear", glyph: "⚙️" },
-  { value: ":sparkles:", label: "Sparkles", glyph: "✨" },
-  { value: ":rocket:", label: "Rocket", glyph: "🚀" },
-  { value: ":megaphone:", label: "Megaphone", glyph: "📣" },
+  { value: ":alarm_clock:", label: "Alarm Clock", glyph: "⏰" },
+  { value: ":art:", label: "Art", glyph: "🎨" },
+  { value: ":brain:", label: "Brain", glyph: "🧠" },
+  { value: ":wrench:", label: "Builder", glyph: "🔧" },
+  { value: ":dart:", label: "Bullseye", glyph: "🎯" },
+  { value: ":computer:", label: "Computer", glyph: "💻" },
   { value: ":chart_with_upwards_trend:", label: "Growth", glyph: "📈" },
   { value: ":bulb:", label: "Idea", glyph: "💡" },
-  { value: ":wrench:", label: "Builder", glyph: "🔧" },
-  { value: ":shield:", label: "Shield", glyph: "🛡️" },
+  { value: ":zap:", label: "Lightning", glyph: "⚡" },
+  { value: ":lock:", label: "Lock", glyph: "🔒" },
+  { value: ":mailbox:", label: "Mailbox", glyph: "📬" },
+  { value: ":megaphone:", label: "Megaphone", glyph: "📣" },
   { value: ":memo:", label: "Notes", glyph: "📝" },
-  { value: ":brain:", label: "Brain", glyph: "🧠" },
+  { value: ":owl:", label: "Owl", glyph: "🦉" },
+  { value: ":robot:", label: "Robot", glyph: "🤖" },
+  { value: ":rocket:", label: "Rocket", glyph: "🚀" },
+  { value: ":mag:", label: "Search", glyph: "🔍" },
+  { value: ":shield:", label: "Shield", glyph: "🛡️" },
+  { value: ":sparkles:", label: "Sparkles", glyph: "✨" },
 ];
 
 const getBoardOptions = (boards: BoardRead[]): SearchableSelectOption[] =>

--- a/frontend/src/app/boards/[boardId]/page.tsx
+++ b/frontend/src/app/boards/[boardId]/page.tsx
@@ -521,15 +521,25 @@ const statusOptions = [
 
 const EMOJI_GLYPHS: Record<string, string> = {
   ":gear:": "⚙️",
-  ":sparkles:": "✨",
-  ":rocket:": "🚀",
-  ":megaphone:": "📣",
+  ":alarm_clock:": "⏰",
+  ":art:": "🎨",
+  ":brain:": "🧠",
+  ":wrench:": "🔧",
+  ":dart:": "🎯",
+  ":computer:": "💻",
   ":chart_with_upwards_trend:": "📈",
   ":bulb:": "💡",
-  ":wrench:": "🔧",
-  ":shield:": "🛡️",
+  ":zap:": "⚡",
+  ":lock:": "🔒",
+  ":mailbox:": "📬",
+  ":megaphone:": "📣",
   ":memo:": "📝",
-  ":brain:": "🧠",
+  ":owl:": "🦉",
+  ":robot:": "🤖",
+  ":rocket:": "🚀",
+  ":mag:": "🔍",
+  ":shield:": "🛡️",
+  ":sparkles:": "✨",
 };
 
 const SSE_RECONNECT_BACKOFF = {


### PR DESCRIPTION
## Summary
- Add 10 new emoji options for agent identity profiles: ⚡ Lightning, 🦉 Owl, 🔍 Search, 💻 Computer, 🔒 Lock, 🎯 Bullseye, 🤖 Robot, ⏰ Alarm Clock, 🎨 Art, 📬 Mailbox
- Sort all emoji options alphabetically by label, keeping Gear (default) first
- Updated `EMOJI_OPTIONS` in both the agent create and edit forms
- Updated `EMOJI_GLYPHS` resolver on the board page for display

## Test plan
- [x] Verify new emoji options appear in the agent create form dropdown
- [x] Verify new emoji options appear in the agent edit form dropdown
- [x] Verify selecting a new emoji persists and renders correctly on the board view
- [x] Verify dropdown order is alphabetical with Gear first