### PR TITLE
fix(backend): Return None instead of 401 when agent not found in get_agent_auth_context_optional

### DIFF
--- a/backend/app/core/agent_auth.py
+++ b/backend/app/core/agent_auth.py
@@ -168,11 +168,12 @@ async def get_agent_auth_context_optional(
         return None
     agent = await _find_agent_for_token(session, resolved)
     if agent is None:
-        logger.warning(
-            "agent auth optional invalid token path=%s token_prefix=%s",
-            request.url.path,
-            resolved[:6],
-        )
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        if agent_token:
+            logger.warning(
+                "agent auth optional invalid token path=%s token_prefix=%s",
+                request.url.path,
+                resolved[:6],
+            )
+        return None
     await _touch_agent_presence(request, session, agent)
     return AgentAuthContext(actor_type="agent", agent=agent)


### PR DESCRIPTION
### Description
This PR fixes a bug in [get_agent_auth_context_optional](cci:1://file:///Users/hanushhnair/Documents/openclaw/openclaw-mission-control/backend/app/core/agent_auth.py:139:0-178:60) where a `401 Unauthorized` exception was incorrectly raised when an agent could not be found for a provided token. 
Because this is the "optional" dependency meant to fall back to user authentication if agent auth isn't present, raising a `401` here incorrectly blocked standard user requests (like Gateway creation or other API operations relying on `ACTOR_DEP`) whenever a bearer token that didn't match a known agent was present.

### Changes Made
- Modified [app/core/agent_auth.py](cci:7://file:///Users/hanushhnair/Documents/openclaw/openclaw-mission-control/backend/app/core/agent_auth.py:0:0-0:0) -> [get_agent_auth_context_optional()](cci:1://file:///Users/hanushhnair/Documents/openclaw/openclaw-mission-control/backend/app/core/agent_auth.py:139:0-178:60) to safely return `None` (after logging a warning) instead of raising `HTTPException(401)` when `agent is None`. 
### Testing
- Verified that Gateway creation from the Mission Control UI using a local auth token successfully completes without throwing 401 errors.
