### PR TITLE
fix: unblock approved close_task — 401 approvals PATCH + lead status gate on in_progress tasks

### DIFF
--- a/backend/app/api/approvals.py
+++ b/backend/app/api/approvals.py
@@ -437,10 +437,21 @@ async def create_approval(
 async def update_approval(
     approval_id: str,
     payload: ApprovalUpdate,
-    board: Board = BOARD_USER_WRITE_DEP,
+    board: Board = BOARD_WRITE_DEP,
     session: AsyncSession = SESSION_DEP,
+    actor: ActorContext = ACTOR_DEP,
 ) -> ApprovalRead:
-    """Update an approval's status and resolution timestamp."""
+    """Update an approval's status and resolution timestamp.
+
+    Accessible by authenticated users with board write access, or by the board's
+    lead agent. Non-lead agents cannot resolve approvals.
+    """
+    if actor.actor_type == "agent":
+        if actor.agent is None or not actor.agent.is_board_lead:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only board lead agents can update approvals.",
+            )
     approval = await Approval.objects.by_id(approval_id).first(session)
     if approval is None or approval.board_id != board.id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -2106,15 +2106,30 @@ async def _lead_apply_status(
     lead_agent = update.actor.agent
     if "status" not in update.updates:
         return
-    if update.task.status != "review":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Lead status gate failed: board leads can only change status when the current "
-                f"task status is `review` (current: `{update.task.status}`)."
-            ),
-        )
     target_status = _required_status_value(update.updates["status"])
+
+    # When the board does not require review before done, allow the lead to move
+    # an in_progress task directly to done (approval gate is still enforced later).
+    # When require_review_before_done is enabled, the task must pass through review first.
+    if update.task.status != "review":
+        # Allow in_progress → done/inbox when review is not required by the board.
+        requires_review = (
+            await session.exec(
+                select(col(Board.require_review_before_done)).where(
+                    col(Board.id) == update.board_id,
+                ),
+            )
+        ).first()
+        allowed_without_review = not requires_review and target_status in {"done", "inbox"}
+        if not allowed_without_review:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "Lead status gate failed: board leads can only change status when the current "
+                    f"task status is `review` (current: `{update.task.status}`)."
+                ),
+            )
+
     if target_status not in {"done", "inbox"}:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
## Problem

Two failure modes prevent approved `close_task` actions from completing:

### Bug 1: 401 on `PATCH /api/v1/boards/{board_id}/approvals/{approval_id}`

`update_approval` used `get_board_for_user_write` (requires `auth.user`) — agents get 401. Board lead agents had no API access to resolve approvals after receiving the resolution notification.

**Fix:** Changed dep to `get_board_for_actor_write`. Added guard: non-lead agents → 403.

### Bug 2: Lead status gate blocks in_progress → done on boards with `require_review_before_done=false`

`_lead_apply_status` unconditionally required `task.status == 'review'`. On Business Ops (`require_review_before_done=false`, `require_approval_for_done=true`), approved close_task actions could never complete.

**Fix:** Queries `require_review_before_done` at runtime. When false, allows `in_progress` → `done`/`inbox` directly. Approval gate (`_require_approved_linked_approval_for_done`) still enforced independently.

## Reproduced with

Task `5652506a` (Business Ops board `cadafdf5`) — status `in_progress`, approval `87817da0` (close_task) already `approved`, Atlas (lead) blocked from closing.

## Validation

- **Fix 1:** Board lead agent now gets 200 on `PATCH /boards/{id}/approvals/{id}` ✅ (was 401)
- **Fix 1 gate:** Non-lead agent / wrong-board agent → 403 ✅
- **Fix 2:** Infra board (`require_review_before_done=true`) still blocks correctly ✅
- **Fix 2:** Business Ops code path — `allowed_without_review=true`, gate skipped ✅
- Rebased on latest upstream master; hot-patched + healthz ok

## Files changed
- `backend/app/api/approvals.py`: `update_approval` — user-only dep → actor-accessible, lead guard added
- `backend/app/api/tasks.py`: `_lead_apply_status` — board-rule-aware status gate; rebased on upstream changes to this function