### PR TITLE
fix: apply disable_device_pairing startup override via env var

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -68,6 +68,12 @@ class Settings(BaseSettings):
 
     # OpenClaw gateway runtime compatibility
     gateway_min_version: str = "2026.02.9"
+    # Comma-separated gateway UUIDs to force disable_device_pairing=True on startup.
+    # Use this to permanently override pairing mode for known gateways.
+    gateway_disable_device_pairing_ids: str = Field(
+        default="",
+        alias="GATEWAY_DISABLE_DEVICE_PAIRING_IDS",
+    )
 
     # Logging
     log_level: str = "INFO"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,8 +35,9 @@ from app.core.config import settings
 from app.core.error_handling import install_error_handling
 from app.core.logging import configure_logging, get_logger
 from app.core.security_headers import SecurityHeadersMiddleware
-from app.db.session import init_db
+from app.db.session import async_session_maker, init_db
 from app.schemas.health import HealthStatusResponse
+from app.services.openclaw.gateway_startup import apply_gateway_startup_overrides
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -437,6 +438,8 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         settings.db_auto_migrate,
     )
     await init_db()
+    async with async_session_maker() as session:
+        await apply_gateway_startup_overrides(session)
     logger.info("app.lifecycle.started")
     try:
         yield

--- a/backend/app/services/openclaw/gateway_startup.py
+++ b/backend/app/services/openclaw/gateway_startup.py
@@ -1,0 +1,59 @@
+"""Startup-time gateway configuration overrides."""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.models.gateways import Gateway
+
+logger = logging.getLogger(__name__)
+
+
+async def apply_gateway_startup_overrides(session: AsyncSession) -> None:
+    """Apply env-var-driven gateway field overrides on startup.
+
+    Idempotent: only writes rows that need changing.
+    """
+    raw: str = settings.gateway_disable_device_pairing_ids.strip()
+    if not raw:
+        return
+
+    ids: list[UUID] = []
+    for part in raw.split(","):
+        value = part.strip()
+        if not value:
+            continue
+        try:
+            ids.append(UUID(value))
+        except ValueError:
+            logger.warning("gateway_startup.invalid_uuid value=%s", value)
+
+    if not ids:
+        return
+
+    result = await session.exec(
+        sa.select(Gateway.id)
+        .where(Gateway.id.in_(ids))
+        .where(Gateway.disable_device_pairing.is_(False)),
+    )
+    gateway_ids_to_update: list[UUID] = [gateway_id for (gateway_id,) in result.all()]
+    if not gateway_ids_to_update:
+        logger.debug("gateway_startup.disable_device_pairing.no_changes_needed")
+        return
+
+    await session.exec(
+        sa.update(Gateway)
+        .where(Gateway.id.in_(gateway_ids_to_update))
+        .values(disable_device_pairing=True),
+    )
+    await session.commit()
+    logger.info(
+        "gateway_startup.disable_device_pairing.applied count=%d ids=%s",
+        len(gateway_ids_to_update),
+        [str(gateway_id) for gateway_id in gateway_ids_to_update],
+    )

--- a/backend/tests/test_gateway_startup_overrides.py
+++ b/backend/tests/test_gateway_startup_overrides.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.models.gateways import Gateway
+from app.models.organizations import Organization
+from app.services.openclaw.gateway_startup import apply_gateway_startup_overrides
+
+
+async def _make_engine() -> AsyncEngine:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.connect() as conn, conn.begin():
+        await conn.run_sync(SQLModel.metadata.create_all)
+    return engine
+
+
+async def _make_session(engine: AsyncEngine) -> AsyncSession:
+    return AsyncSession(engine, expire_on_commit=False)
+
+
+async def _seed_gateway(
+    session: AsyncSession,
+    *,
+    gateway_id: UUID | None = None,
+    disable_device_pairing: bool,
+) -> Gateway:
+    organization_id = uuid4()
+    gateway = Gateway(
+        id=gateway_id or uuid4(),
+        organization_id=organization_id,
+        name=f"gateway-{organization_id}",
+        url="https://gateway.local",
+        disable_device_pairing=disable_device_pairing,
+        workspace_root="/tmp/workspace",
+    )
+    session.add(Organization(id=organization_id, name=f"org-{organization_id}"))
+    session.add(gateway)
+    await session.commit()
+    return gateway
+
+
+@pytest.mark.asyncio
+async def test_sets_disable_device_pairing_for_listed_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = await _make_engine()
+    try:
+        async with await _make_session(engine) as session:
+            gateway = await _seed_gateway(session, disable_device_pairing=False)
+            monkeypatch.setattr(
+                settings,
+                "gateway_disable_device_pairing_ids",
+                str(gateway.id),
+            )
+
+            await apply_gateway_startup_overrides(session)
+            await session.refresh(gateway)
+
+            assert gateway.disable_device_pairing is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_skips_already_disabled_gateways(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = await _make_engine()
+    try:
+        async with await _make_session(engine) as session:
+            gateway = await _seed_gateway(session, disable_device_pairing=True)
+            original_updated_at: datetime = gateway.updated_at
+            monkeypatch.setattr(
+                settings,
+                "gateway_disable_device_pairing_ids",
+                str(gateway.id),
+            )
+
+            await apply_gateway_startup_overrides(session)
+            await session.refresh(gateway)
+
+            assert gateway.disable_device_pairing is True
+            assert gateway.updated_at == original_updated_at
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ignores_unlisted_gateways(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = await _make_engine()
+    try:
+        async with await _make_session(engine) as session:
+            listed_gateway = await _seed_gateway(session, disable_device_pairing=False)
+            unlisted_gateway = await _seed_gateway(session, disable_device_pairing=False)
+            monkeypatch.setattr(
+                settings,
+                "gateway_disable_device_pairing_ids",
+                str(listed_gateway.id),
+            )
+
+            await apply_gateway_startup_overrides(session)
+            await session.refresh(listed_gateway)
+            await session.refresh(unlisted_gateway)
+
+            assert listed_gateway.disable_device_pairing is True
+            assert unlisted_gateway.disable_device_pairing is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_empty_env_var_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = await _make_engine()
+    try:
+        async with await _make_session(engine) as session:
+            gateway = await _seed_gateway(session, disable_device_pairing=False)
+            monkeypatch.setattr(settings, "gateway_disable_device_pairing_ids", "")
+
+            await apply_gateway_startup_overrides(session)
+            await session.refresh(gateway)
+
+            assert gateway.disable_device_pairing is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_invalid_uuid_is_logged_and_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    engine = await _make_engine()
+    try:
+        async with await _make_session(engine) as session:
+            gateway = await _seed_gateway(session, disable_device_pairing=False)
+            monkeypatch.setattr(
+                settings,
+                "gateway_disable_device_pairing_ids",
+                f"not-a-uuid,{gateway.id}",
+            )
+            caplog.set_level("WARNING")
+
+            await apply_gateway_startup_overrides(session)
+            await session.refresh(gateway)
+
+            assert gateway.disable_device_pairing is True
+            assert "gateway_startup.invalid_uuid value=not-a-uuid" in caplog.text
+    finally:
+        await engine.dispose()

--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,9 @@ services:
       AUTH_MODE: ${AUTH_MODE}
       LOCAL_AUTH_TOKEN: ${LOCAL_AUTH_TOKEN}
       RQ_REDIS_URL: redis://redis:6379/0
+      # Force disable_device_pairing=true for specific gateways on startup.
+      # Prevents pairing-required loops after container restarts.
+      # GATEWAY_DISABLE_DEVICE_PAIRING_IDS: "uuid1,uuid2"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Fixes P0 recurring issue: every MC Docker restart resets `disable_device_pairing` to `False`, causing a pairing-required loop that breaks all board-lead dispatch.

## Root Cause

`disable_device_pairing` defaults to `False` in the Gateway model. Any provisioning or upsert path that runs post-restart can reset the field to its default, requiring manual `UPDATE gateways SET disable_device_pairing=true` + restart each time.

## Fix: env-var-driven startup override (idempotent)

Add `GATEWAY_DISABLE_DEVICE_PAIRING_IDS` env var (comma-separated gateway UUIDs). On startup, after `init_db()`, MC calls `apply_gateway_startup_overrides()` which sets `disable_device_pairing=True` for listed gateways. Only writes rows that need changing. No-op if already set. No DB migration required.

**One-time setup to activate:**
```
# backend/.env
GATEWAY_DISABLE_DEVICE_PAIRING_IDS=40666076-e8f6-45a8-8eef-c1078936aa18
```

After that, every `docker compose restart` self-heals. No more manual DB intervention.

## Changed Files
- `backend/app/core/config.py` — new `gateway_disable_device_pairing_ids` setting
- `backend/app/main.py` — call `apply_gateway_startup_overrides` in `lifespan`
- `backend/app/services/openclaw/gateway_startup.py` — new startup hook (new file)
- `backend/tests/test_gateway_startup_overrides.py` — 5 test cases (new file)
- `compose.yml` — documented env var comment

## Test Plan
- [ ] Provision MC with `GATEWAY_DISABLE_DEVICE_PAIRING_IDS=<gateway-uuid>` in backend env
- [ ] Run `docker compose restart` — verify `disable_device_pairing` stays `True` in DB
- [ ] Verify board-lead dispatch works without manual DB fix after restart
- [ ] Run `pytest backend/tests/test_gateway_startup_overrides.py` — all 5 pass

Correlation-ID: forge-mc-pairing-permanent-fix