### PR TITLE
fix: resolve GlobalLoader hydration mismatch in Next.js SSR

### DIFF
--- a/frontend/src/components/ui/global-loader.tsx
+++ b/frontend/src/components/ui/global-loader.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
 export function GlobalLoader() {
+  const [mounted, setMounted] = useState(false);
   const fetchingCount = useIsFetching({
     predicate: (query) =>
       query.state.fetchStatus === "fetching" && query.state.data === undefined,
   });
   const mutatingCount = useIsMutating();
-  const visible = fetchingCount + mutatingCount > 0;
+  const visible = mounted && fetchingCount + mutatingCount > 0;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## Problem

`GlobalLoader` uses `useIsFetching` and `useIsMutating` from React Query,
which return different values on the server vs client during hydration.
This causes a React hydration mismatch error visible in the browser console:

> Hydration failed because the server rendered HTML didn't match the client.

The server renders the component with one state while the client hydrates
with another, triggering a full tree regeneration on the client.

## Fix

Add a `mounted` guard so `visible` is always `false` during SSR and initial
hydration. The loader only activates after the component mounts on the client,
ensuring server and client produce identical initial HTML.

## Changes

- `frontend/src/components/ui/global-loader.tsx` — add `useState`/`useEffect`
  mounted guard before evaluating fetch/mutation counts
