### PR TITLE
fix: retry lead agent provisioning on confirm after gateway race condition

### DIFF
--- a/backend/app/services/openclaw/provisioning.py
+++ b/backend/app/services/openclaw/provisioning.py
@@ -7,6 +7,7 @@ DB-backed workflows (template sync, lead-agent record creation) live in
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from abc import ABC, abstractmethod
@@ -554,6 +555,7 @@ class OpenClawGatewayControlPlane(GatewayControlPlane):
         # Prefer an idempotent "create then update" flow.
         # - Avoids enumerating gateway agents for existence checks.
         # - Ensures we always hit the "create" RPC first, per lifecycle expectations.
+        created = False
         try:
             await openclaw_call(
                 "agents.create",
@@ -563,21 +565,30 @@ class OpenClawGatewayControlPlane(GatewayControlPlane):
                 },
                 config=self._config,
             )
+            created = True
         except OpenClawGatewayError as exc:
             message = str(exc).lower()
             if not any(
                 marker in message for marker in ("already", "exist", "duplicate", "conflict")
             ):
                 raise
-        await openclaw_call(
-            "agents.update",
-            {
-                "agentId": registration.agent_id,
-                "name": registration.name,
-                "workspace": registration.workspace_path,
-            },
-            config=self._config,
-        )
+
+        update_params = {
+            "agentId": registration.agent_id,
+            "name": registration.name,
+            "workspace": registration.workspace_path,
+        }
+        try:
+            await openclaw_call("agents.update", update_params, config=self._config)
+        except OpenClawGatewayError as exc:
+            # Gateway race condition: agents.create succeeds but the agent
+            # isn't visible yet when agents.update runs immediately after.
+            # Retry once after a short delay only when we just created it.
+            if not (created and _is_missing_agent_error(exc)):
+                raise
+            await asyncio.sleep(0.5)
+            await openclaw_call("agents.update", update_params, config=self._config)
+
         await self.patch_agent_heartbeats(
             [(registration.agent_id, registration.workspace_path, registration.heartbeat)],
         )

--- a/backend/app/services/openclaw/provisioning_db.py
+++ b/backend/app/services/openclaw/provisioning_db.py
@@ -185,6 +185,31 @@ class OpenClawProvisioningService(OpenClawDBService):
                 self.session.add(existing)
                 await self.session.commit()
                 await self.session.refresh(existing)
+
+            # If the agent has a prior provisioning error (e.g. gateway race
+            # condition on the first attempt), re-run the lifecycle instead of
+            # returning the broken record.  This is safe for concurrent clicks
+            # because ``run_lifecycle`` acquires a ``FOR UPDATE`` lock.
+            if existing.last_provision_error:
+                raw_token = mint_agent_token(existing)
+                await self.session.commit()
+                await self.session.refresh(existing)
+                existing = await AgentLifecycleOrchestrator(self.session).run_lifecycle(
+                    gateway=request.gateway,
+                    agent_id=existing.id,
+                    board=board,
+                    user=request.user,
+                    action=config_options.action,
+                    auth_token=raw_token,
+                    force_bootstrap=False,
+                    reset_session=False,
+                    wake=True,
+                    deliver_wakeup=True,
+                    wakeup_verb=None,
+                    clear_confirm_token=False,
+                    raise_gateway_errors=True,
+                )
+
             return existing, False
 
         merged_identity_profile: dict[str, Any] = {

--- a/backend/tests/test_agent_provisioning_utils.py
+++ b/backend/tests/test_agent_provisioning_utils.py
@@ -681,3 +681,86 @@ async def test_delete_agent_lifecycle_raises_on_non_missing_agent_error(monkeypa
             delete_files=True,
             delete_session=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_retries_update_after_create_race(monkeypatch):
+    """agents.create succeeds but the first agents.update raises 'not found' due to
+    a gateway race condition.  upsert_agent should retry once and succeed."""
+    calls: list[tuple[str, dict[str, object] | None]] = []
+    update_attempt = 0
+
+    async def _fake_openclaw_call(method, params=None, config=None):
+        nonlocal update_attempt
+        _ = config
+        calls.append((method, params))
+        if method == "agents.create":
+            return {"ok": True}
+        if method == "agents.update":
+            update_attempt += 1
+            if update_attempt == 1:
+                raise agent_provisioning.OpenClawGatewayError('agent "lead-abc" not found')
+            return {"ok": True}
+        if method == "config.get":
+            return {"hash": None, "config": {"agents": {"list": []}}}
+        if method == "config.patch":
+            return {"ok": True}
+        raise AssertionError(f"Unexpected method: {method}")
+
+    # Eliminate the 0.5s sleep in tests
+    async def _noop_sleep(_):
+        pass
+
+    monkeypatch.setattr(agent_provisioning.asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(agent_provisioning, "openclaw_call", _fake_openclaw_call)
+
+    cp = agent_provisioning.OpenClawGatewayControlPlane(
+        agent_provisioning.GatewayClientConfig(url="ws://gateway.example/ws", token=None),
+    )
+    await cp.upsert_agent(
+        agent_provisioning.GatewayAgentRegistration(
+            agent_id="lead-abc",
+            name="Lead Agent",
+            workspace_path="/tmp/workspace-lead-abc",
+            heartbeat={"every": "10m", "target": "last", "includeReasoning": False},
+        ),
+    )
+
+    method_names = [c[0] for c in calls]
+    assert method_names.count("agents.create") == 1
+    assert method_names.count("agents.update") == 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_no_retry_when_already_existed(monkeypatch):
+    """If agents.create raised 'already exists' (agent was NOT just created),
+    an agents.update 'not found' error should propagate without retry."""
+    calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def _fake_openclaw_call(method, params=None, config=None):
+        _ = config
+        calls.append((method, params))
+        if method == "agents.create":
+            raise agent_provisioning.OpenClawGatewayError("already exists")
+        if method == "agents.update":
+            raise agent_provisioning.OpenClawGatewayError('agent "lead-abc" not found')
+        raise AssertionError(f"Unexpected method: {method}")
+
+    monkeypatch.setattr(agent_provisioning, "openclaw_call", _fake_openclaw_call)
+
+    cp = agent_provisioning.OpenClawGatewayControlPlane(
+        agent_provisioning.GatewayClientConfig(url="ws://gateway.example/ws", token=None),
+    )
+    with pytest.raises(agent_provisioning.OpenClawGatewayError, match="not found"):
+        await cp.upsert_agent(
+            agent_provisioning.GatewayAgentRegistration(
+                agent_id="lead-abc",
+                name="Lead Agent",
+                workspace_path="/tmp/workspace-lead-abc",
+                heartbeat={"every": "10m", "target": "last", "includeReasoning": False},
+            ),
+        )
+
+    method_names = [c[0] for c in calls]
+    assert method_names.count("agents.create") == 1
+    assert method_names.count("agents.update") == 1


### PR DESCRIPTION
 When a user clicks "Confirm Goal" after board onboarding, the gateway can return "agent not found" during agents.update due to a race condition where agents.create succeeds but the agent isn't yet    
  visible. Worse, clicking "Confirm Goal" again does not retry because the existing agent DB record is returned immediately without re-running provisioning.                                              
                                                                  
  - Re-run lifecycle for existing agents that have last_provision_error set
  - Retry agents.update once (after 0.5s) when it fails with "not found" immediately after a successful agents.create
  - Add tests for both the retry and no-retry paths

  Task / context

  - Mission Control task: N/A
  - Why: Lead agent gets permanently stuck after a gateway race condition on first provision — users have no way to recover without manual DB intervention

  Scope

  - provisioning_db.py: Re-provision existing agents that have a prior last_provision_error instead of returning early
  - provisioning.py: Add single retry with 0.5s delay for agents.update "not found" after a successful agents.create
  - test_agent_provisioning_utils.py: Two new test cases covering retry and no-retry paths

  Out of scope

  - Exponential backoff / configurable retry count (single retry is sufficient for this race window)
  - Gateway-side fix for the create-then-update visibility gap
  - UI-side retry / loading state changes

  Evidence / validation

  - make check (or explain what you ran instead): python -m pytest tests/ -v — 379 passed, 1 xfailed, 0 failures
  - E2E (if applicable): not applicable (gateway race condition not reproducible in local E2E)
  - Logs/links:
    - python -m pytest tests/test_agent_provisioning_utils.py -v — 24/24 passed
    - python -m pytest tests/test_boards_delete.py -v — 3/3 passed


  Docs impact

  - No user/operator docs changes required
  - Docs updated: N/A

  Risk / rollout notes

  - Risk level: low
  - Rollback plan (if needed): Revert this commit; agents stuck with last_provision_error can be manually cleared via DB

## Checklist
- [x] Branch created from `origin/master` (no unrelated commits)
- [x] PR is focused (one theme)
- [x] No secrets in code/logs/docs
- [x] If API/behavior changes: docs updated (OpenAPI + `docs/reference/api.md`)
