### PR TITLE
feat(frontend): improve Mission Control mobile shell + sidebar UX

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -437,10 +437,10 @@ export default function DashboardPage() {
       <SignedIn>
         <DashboardSidebar />
         <main className="flex-1 overflow-y-auto bg-slate-50">
-          <div className="border-b border-slate-200 bg-white px-8 py-6">
-            <div className="flex items-center justify-between gap-4">
+          <div className="border-b border-slate-200 bg-white px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
-                <h2 className="font-heading text-2xl font-semibold text-slate-900 tracking-tight">
+                <h2 className="font-heading text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">
                   Dashboard
                 </h2>
                 <p className="mt-1 text-sm text-slate-500">
@@ -535,7 +535,7 @@ export default function DashboardPage() {
               </div>
             </div>
           </div>
-          <div className="p-8">
+          <div className="p-4 sm:p-6 lg:p-8">
             {metricsQuery.error ? (
               <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
                 {metricsQuery.error.message}

--- a/frontend/src/components/organisms/DashboardSidebar.tsx
+++ b/frontend/src/components/organisms/DashboardSidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import {
   Activity,
   BarChart3,
@@ -15,6 +16,8 @@ import {
   Settings,
   Store,
   Tags,
+  Menu,
+  X,
 } from "lucide-react";
 
 import { useAuth } from "@/auth/clerk";
@@ -28,6 +31,7 @@ import { cn } from "@/lib/utils";
 
 export function DashboardSidebar() {
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
   const { isSignedIn } = useAuth();
   const { isAdmin } = useOrganizationMembership(isSignedIn);
   const healthQuery = useHealthzHealthzGet<healthzHealthzGetResponse, ApiError>(
@@ -58,12 +62,39 @@ export function DashboardSidebar() {
         : "System degraded";
 
   return (
-    <aside className="flex h-full w-64 flex-col border-r border-slate-200 bg-white">
-      <div className="flex-1 px-3 py-4">
-        <p className="px-3 text-xs font-semibold uppercase tracking-wider text-slate-500">
-          Navigation
-        </p>
-        <nav className="mt-3 space-y-4 text-sm">
+    <>
+      <button
+        type="button"
+        onClick={() => setMobileOpen((prev) => !prev)}
+        className="fixed left-3 top-3 z-50 inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm lg:hidden"
+        aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
+      >
+        {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+      </button>
+
+      {mobileOpen ? (
+        <button
+          type="button"
+          aria-label="Close navigation overlay"
+          onClick={() => setMobileOpen(false)}
+          className="fixed inset-0 z-40 bg-slate-900/30 lg:hidden"
+        />
+      ) : null}
+
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-50 flex w-72 max-w-[85vw] flex-col border-r border-slate-200 bg-white transition-transform duration-200 lg:static lg:z-auto lg:h-full lg:w-64 lg:max-w-none lg:translate-x-0",
+          mobileOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
+        <div className="flex-1 overflow-y-auto px-3 py-4">
+          <p className="px-3 text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Navigation
+          </p>
+          <nav
+            className="mt-3 space-y-4 text-sm"
+            onClick={() => setMobileOpen(false)}
+          >
           <div>
             <p className="px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400">
               Overview
@@ -252,19 +283,20 @@ export function DashboardSidebar() {
           </div>
         </nav>
       </div>
-      <div className="border-t border-slate-200 p-4">
-        <div className="flex items-center gap-2 text-xs text-slate-500">
-          <span
-            className={cn(
-              "h-2 w-2 rounded-full",
-              systemStatus === "operational" && "bg-emerald-500",
-              systemStatus === "degraded" && "bg-rose-500",
-              systemStatus === "unknown" && "bg-slate-300",
-            )}
-          />
-          {statusLabel}
+        <div className="border-t border-slate-200 p-4">
+          <div className="flex items-center gap-2 text-xs text-slate-500">
+            <span
+              className={cn(
+                "h-2 w-2 rounded-full",
+                systemStatus === "operational" && "bg-emerald-500",
+                systemStatus === "degraded" && "bg-rose-500",
+                systemStatus === "unknown" && "bg-slate-300",
+              )}
+            />
+            {statusLabel}
+          </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/frontend/src/components/templates/DashboardShell.tsx
+++ b/frontend/src/components/templates/DashboardShell.tsx
@@ -71,19 +71,19 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-app text-strong">
       <header className="sticky top-0 z-40 border-b border-slate-200 bg-white shadow-sm">
-        <div className="grid grid-cols-[260px_1fr_auto] items-center gap-0 py-3">
-          <div className="flex items-center px-6">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-0 py-3 lg:grid-cols-[260px_1fr_auto]">
+          <div className="flex items-center px-4 pl-14 lg:px-6 lg:pl-6">
             <BrandMark />
           </div>
           <SignedIn>
-            <div className="flex items-center">
+            <div className="hidden items-center lg:flex">
               <div className="max-w-[220px]">
                 <OrgSwitcher />
               </div>
             </div>
           </SignedIn>
           <SignedIn>
-            <div className="flex items-center gap-3 px-6">
+            <div className="flex items-center gap-3 px-4 lg:px-6">
               <div className="hidden text-right lg:block">
                 <p className="text-sm font-semibold text-slate-900">
                   {displayName}
@@ -95,7 +95,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
           </SignedIn>
         </div>
       </header>
-      <div className="grid min-h-[calc(100vh-64px)] grid-cols-[260px_1fr] bg-slate-50">
+      <div className="grid min-h-[calc(100vh-64px)] grid-cols-1 bg-slate-50 lg:grid-cols-[260px_1fr]">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR improves mobile responsiveness for Mission Control dashboard surfaces without changing backend behavior or auth logic.

### Changes
- Add mobile sidebar drawer (hamburger + overlay + close behavior) in `DashboardSidebar`
- Keep desktop sidebar behavior unchanged (`lg` and up)
- Make dashboard shell grid responsive in `DashboardShell`
- Adjust dashboard header/content spacing + title scale for small screens

## Why
On narrow viewports, the fixed desktop shell/sidebar consumed most horizontal space and made core content difficult to use.

## Scope
- Frontend only
- No API changes
- No runtime/config behavior changes

## Files
- `frontend/src/components/organisms/DashboardSidebar.tsx`
- `frontend/src/components/templates/DashboardShell.tsx`
- `frontend/src/app/dashboard/page.tsx`
