### PR TITLE
fix: 使用客户端路由刷新替代全页刷新

### DIFF
--- a/frontend/src/components/templates/DashboardShell.tsx
+++ b/frontend/src/components/templates/DashboardShell.tsx
@@ -58,7 +58,8 @@ export function DashboardShell({ children }: { children: ReactNode }) {
 
     const handleStorage = (event: StorageEvent) => {
       if (event.key !== "openclaw_org_switch" || !event.newValue) return;
-      window.location.reload();
+      // 使用客户端路由刷新替代全页刷新，提升性能
+      router.refresh();
     };
 
     window.addEventListener("storage", handleStorage);
@@ -67,7 +68,8 @@ export function DashboardShell({ children }: { children: ReactNode }) {
     if ("BroadcastChannel" in window) {
       channel = new BroadcastChannel("org-switch");
       channel.onmessage = () => {
-        window.location.reload();
+        // 使用客户端路由刷新替代全页刷新，提升性能
+        router.refresh();
       };
     }
 
@@ -75,7 +77,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
       window.removeEventListener("storage", handleStorage);
       channel?.close();
     };
-  }, []);
+  }, [router]);
 
   const toggleSidebar = useCallback(
     () => setSidebarState((prev) => ({ open: !prev.open, path: pathname })),


### PR DESCRIPTION
## 变更说明
- 将 window.location.reload() 替换为 router.refresh()
- 避免每次切换页面时完全刷新整个页面，提升性能
- 添加 router 依赖到 useEffect 依赖数组

## 修复位置
- frontend/src/components/templates/DashboardShell.tsx

## 验收标准
- [x] 切换页面时不再刷新整个页面
- [x] 使用客户端导航