### PR TITLE
security: redact gateway tokens + avoid query-string auth leaks

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,9 +10,9 @@ CORS_ORIGINS=http://localhost:3000
 # REQUIRED for gateway provisioning/agent heartbeats. Must be reachable by gateway runtime.
 BASE_URL=
 # Security response headers (blank values disable each header).
-SECURITY_HEADER_X_CONTENT_TYPE_OPTIONS=
-SECURITY_HEADER_X_FRAME_OPTIONS=
-SECURITY_HEADER_REFERRER_POLICY=
+SECURITY_HEADER_X_CONTENT_TYPE_OPTIONS=nosniff
+SECURITY_HEADER_X_FRAME_OPTIONS=DENY
+SECURITY_HEADER_REFERRER_POLICY=strict-origin-when-cross-origin
 SECURITY_HEADER_PERMISSIONS_POLICY=
 
 # Auth mode: clerk or local.

--- a/backend/app/api/gateway.py
+++ b/backend/app/api/gateway.py
@@ -17,6 +17,7 @@ from app.schemas.gateway_api import (
     GatewaySessionMessageRequest,
     GatewaySessionResponse,
     GatewaySessionsResponse,
+    GatewayStatusCheckRequest,
     GatewaysStatusResponse,
 )
 from app.services.openclaw.gateway_rpc import GATEWAY_EVENTS, GATEWAY_METHODS, PROTOCOL_VERSION
@@ -61,6 +62,29 @@ async def gateways_status(
 ) -> GatewaysStatusResponse:
     """Return gateway connectivity and session status."""
     service = GatewaySessionService(session)
+    return await service.get_status(
+        params=params,
+        organization_id=ctx.organization.id,
+        user=auth.user,
+    )
+
+
+@router.post("/status/check", response_model=GatewaysStatusResponse)
+async def gateways_status_check(
+    payload: GatewayStatusCheckRequest,
+    session: AsyncSession = SESSION_DEP,
+    auth: AuthContext = AUTH_DEP,
+    ctx: OrganizationContext = ORG_ADMIN_DEP,
+) -> GatewaysStatusResponse:
+    """Check gateway connectivity via JSON body (keeps tokens out of query strings)."""
+    service = GatewaySessionService(session)
+    params = GatewaySessionService.to_resolve_query(
+        board_id=None,
+        gateway_url=payload.gateway_url,
+        gateway_token=payload.gateway_token,
+        gateway_disable_device_pairing=payload.gateway_disable_device_pairing,
+        gateway_allow_insecure_tls=payload.gateway_allow_insecure_tls,
+    )
     return await service.get_status(
         params=params,
         organization_id=ctx.organization.id,

--- a/backend/app/api/gateways.py
+++ b/backend/app/api/gateways.py
@@ -72,6 +72,21 @@ def _template_sync_query(
 SYNC_QUERY_DEP = Depends(_template_sync_query)
 
 
+def _to_gateway_read(gateway: Gateway) -> GatewayRead:
+    return GatewayRead(
+        id=gateway.id,
+        organization_id=gateway.organization_id,
+        name=gateway.name,
+        url=gateway.url,
+        workspace_root=gateway.workspace_root,
+        allow_insecure_tls=gateway.allow_insecure_tls,
+        disable_device_pairing=gateway.disable_device_pairing,
+        has_token=bool((gateway.token or "").strip()),
+        created_at=gateway.created_at,
+        updated_at=gateway.updated_at,
+    )
+
+
 @router.get("", response_model=DefaultLimitOffsetPage[GatewayRead])
 async def list_gateways(
     session: AsyncSession = SESSION_DEP,
@@ -84,7 +99,11 @@ async def list_gateways(
         .statement
     )
 
-    return await paginate(session, statement)
+    def _transform(items):
+        gateways = [item for item in items if isinstance(item, Gateway)]
+        return [_to_gateway_read(gateway) for gateway in gateways]
+
+    return await paginate(session, statement, transformer=_transform)
 
 
 @router.post("", response_model=GatewayRead)
@@ -93,7 +112,7 @@ async def create_gateway(
     session: AsyncSession = SESSION_DEP,
     auth: AuthContext = AUTH_DEP,
     ctx: OrganizationContext = ORG_ADMIN_DEP,
-) -> Gateway:
+) -> GatewayRead:
     """Create a gateway and provision or refresh its main agent."""
     service = GatewayAdminLifecycleService(session)
     await service.assert_gateway_runtime_compatible(
@@ -108,7 +127,7 @@ async def create_gateway(
     data["organization_id"] = ctx.organization.id
     gateway = await crud.create(session, Gateway, **data)
     await service.ensure_main_agent(gateway, auth, action="provision")
-    return gateway
+    return _to_gateway_read(gateway)
 
 
 @router.get("/{gateway_id}", response_model=GatewayRead)
@@ -116,14 +135,14 @@ async def get_gateway(
     gateway_id: UUID,
     session: AsyncSession = SESSION_DEP,
     ctx: OrganizationContext = ORG_ADMIN_DEP,
-) -> Gateway:
+) -> GatewayRead:
     """Return one gateway by id for the caller's organization."""
     service = GatewayAdminLifecycleService(session)
     gateway = await service.require_gateway(
         gateway_id=gateway_id,
         organization_id=ctx.organization.id,
     )
-    return gateway
+    return _to_gateway_read(gateway)
 
 
 @router.patch("/{gateway_id}", response_model=GatewayRead)
@@ -133,7 +152,7 @@ async def update_gateway(
     session: AsyncSession = SESSION_DEP,
     auth: AuthContext = AUTH_DEP,
     ctx: OrganizationContext = ORG_ADMIN_DEP,
-) -> Gateway:
+) -> GatewayRead:
     """Patch a gateway and refresh the main-agent provisioning state."""
     service = GatewayAdminLifecycleService(session)
     gateway = await service.require_gateway(
@@ -165,7 +184,7 @@ async def update_gateway(
             )
     await crud.patch(session, gateway, updates)
     await service.ensure_main_agent(gateway, auth, action="update")
-    return gateway
+    return _to_gateway_read(gateway)
 
 
 @router.post("/{gateway_id}/templates/sync", response_model=GatewayTemplatesSyncResult)

--- a/backend/app/schemas/gateway_api.py
+++ b/backend/app/schemas/gateway_api.py
@@ -25,6 +25,15 @@ class GatewayResolveQuery(SQLModel):
     gateway_allow_insecure_tls: bool | None = None
 
 
+class GatewayStatusCheckRequest(SQLModel):
+    """Request payload for gateway reachability checks without query-string tokens."""
+
+    gateway_url: NonEmptyStr
+    gateway_token: str | None = None
+    gateway_disable_device_pairing: bool | None = None
+    gateway_allow_insecure_tls: bool | None = None
+
+
 class GatewaysStatusResponse(SQLModel):
     """Aggregated gateway status response including session metadata."""
 

--- a/backend/app/schemas/gateways.py
+++ b/backend/app/schemas/gateways.py
@@ -65,7 +65,7 @@ class GatewayRead(GatewayBase):
 
     id: UUID
     organization_id: UUID
-    token: str | None = None
+    has_token: bool = False
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/openclaw/gateway_rpc.py
+++ b/backend/app/services/openclaw/gateway_rpc.py
@@ -13,7 +13,7 @@ import ssl
 from dataclasses import dataclass
 from time import perf_counter, time
 from typing import Any, Literal
-from urllib.parse import urlencode, urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 import websockets
@@ -181,12 +181,10 @@ def _build_gateway_url(config: GatewayConfig) -> str:
     if not base_url:
         message = "Gateway URL is not configured."
         raise OpenClawGatewayError(message)
-    token = config.token
-    if not token:
-        return base_url
-    parsed = urlparse(base_url)
-    query = urlencode({"token": token})
-    return str(urlunparse(parsed._replace(query=query)))
+    # Do not append auth tokens to URL query parameters.
+    # Authentication is sent in the connect payload (`params.auth.token`) to
+    # reduce leakage via URL logs and tracing systems.
+    return base_url
 
 
 def _redacted_url_for_log(raw_url: str) -> str:

--- a/backend/app/services/openclaw/session_service.py
+++ b/backend/app/services/openclaw/session_service.py
@@ -117,11 +117,18 @@ class GatewaySessionService(OpenClawDBService):
             if can_query_saved_gateway and (
                 params.gateway_allow_insecure_tls is None
                 or params.gateway_disable_device_pairing is None
+                or token is None
             ):
                 gateway_query = Gateway.objects.filter_by(url=raw_url)
                 if organization_id is not None:
                     gateway_query = gateway_query.filter_by(organization_id=organization_id)
                 gateway = await gateway_query.first(self.session)
+
+            # If callers intentionally omit the token but reference a saved gateway URL,
+            # reuse the stored token server-side to avoid leaking it via query strings.
+            if token is None and gateway is not None:
+                token = (gateway.token or "").strip() or None
+
             allow_insecure_tls = (
                 params.gateway_allow_insecure_tls
                 if params.gateway_allow_insecure_tls is not None

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -50,7 +50,9 @@ Webhook ingest enforces a payload size limit (default **1 MB** / 1,048,576 bytes
 
 ## Gateway tokens
 
-Gateway tokens are currently returned in API responses. A future release will redact them from read endpoints (replacing the raw value with a `has_token` boolean). Until then, treat gateway API responses as sensitive.
+Gateway read endpoints redact raw gateway tokens. Responses expose `has_token` to indicate whether a token is configured, without returning the secret value.
+
+For connectivity checks that require a token, prefer `POST /api/v1/gateways/status/check` with a JSON body instead of query-string tokens.
 
 ## Container security
 

--- a/frontend/src/api/generated/model/gatewayRead.ts
+++ b/frontend/src/api/generated/model/gatewayRead.ts
@@ -15,7 +15,7 @@ export interface GatewayRead {
   id: string;
   name: string;
   organization_id: string;
-  token?: string | null;
+  has_token?: boolean;
   updated_at: string;
   url: string;
   workspace_root: string;

--- a/frontend/src/app/gateways/[gatewayId]/edit/page.tsx
+++ b/frontend/src/app/gateways/[gatewayId]/edit/page.tsx
@@ -87,7 +87,7 @@ export default function EditGatewayPage() {
     gatewayQuery.data?.status === 200 ? gatewayQuery.data.data : null;
   const resolvedName = name ?? loadedGateway?.name ?? "";
   const resolvedGatewayUrl = gatewayUrl ?? loadedGateway?.url ?? "";
-  const resolvedGatewayToken = gatewayToken ?? loadedGateway?.token ?? "";
+  const resolvedGatewayToken = gatewayToken ?? "";
   const resolvedDisableDevicePairing =
     disableDevicePairing ?? loadedGateway?.disable_device_pairing ?? false;
   const resolvedWorkspaceRoot =
@@ -145,11 +145,14 @@ export default function EditGatewayPage() {
     const payload: GatewayUpdate = {
       name: resolvedName.trim(),
       url: resolvedGatewayUrl.trim(),
-      token: resolvedGatewayToken.trim() || null,
       disable_device_pairing: resolvedDisableDevicePairing,
       workspace_root: resolvedWorkspaceRoot.trim(),
       allow_insecure_tls: resolvedAllowInsecureTls,
     };
+
+    if (gatewayToken !== undefined) {
+      payload.token = gatewayToken.trim() || null;
+    }
 
     updateMutation.mutate({ gatewayId, data: payload });
   };

--- a/frontend/src/app/gateways/[gatewayId]/page.tsx
+++ b/frontend/src/app/gateways/[gatewayId]/page.tsx
@@ -34,12 +34,6 @@ import { formatTimestamp } from "@/lib/formatters";
 import { createOptimisticListDeleteMutation } from "@/lib/list-delete";
 import { useOrganizationMembership } from "@/lib/use-organization-membership";
 
-const maskToken = (value?: string | null) => {
-  if (!value) return "—";
-  if (value.length <= 8) return "••••";
-  return `••••${value.slice(-4)}`;
-};
-
 export default function GatewayDetailPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -114,7 +108,6 @@ export default function GatewayDetailPage() {
   const statusParams = gateway
     ? {
         gateway_url: gateway.url,
-        gateway_token: gateway.token ?? undefined,
         gateway_disable_device_pairing: gateway.disable_device_pairing,
         gateway_allow_insecure_tls: gateway.allow_insecure_tls,
       }
@@ -231,7 +224,7 @@ export default function GatewayDetailPage() {
                   <div>
                     <p className="text-xs uppercase text-slate-400">Token</p>
                     <p className="mt-1 text-sm font-medium text-slate-900">
-                      {maskToken(gateway.token)}
+                      {gateway.has_token ? "Configured" : "Not set"}
                     </p>
                   </div>
                   <div>

--- a/frontend/src/lib/gateway-form.ts
+++ b/frontend/src/lib/gateway-form.ts
@@ -1,4 +1,5 @@
-import { gatewaysStatusApiV1GatewaysStatusGet } from "@/api/generated/gateways/gateways";
+import { customFetch } from "@/api/mutator";
+import type { GatewaysStatusResponse } from "@/api/generated/model";
 
 export const DEFAULT_WORKSPACE_ROOT = "~/.openclaw";
 
@@ -78,7 +79,7 @@ export async function checkGatewayConnection(params: {
   gatewayAllowInsecureTls: boolean;
 }): Promise<{ ok: boolean; message: string }> {
   try {
-    const requestParams: {
+    const payload: {
       gateway_url: string;
       gateway_token?: string;
       gateway_disable_device_pairing: boolean;
@@ -89,10 +90,18 @@ export async function checkGatewayConnection(params: {
       gateway_allow_insecure_tls: params.gatewayAllowInsecureTls,
     };
     if (params.gatewayToken.trim()) {
-      requestParams.gateway_token = params.gatewayToken.trim();
+      payload.gateway_token = params.gatewayToken.trim();
     }
 
-    const response = await gatewaysStatusApiV1GatewaysStatusGet(requestParams);
+    const response = await customFetch<{
+      data: GatewaysStatusResponse;
+      status: number;
+      headers: Headers;
+    }>("/api/v1/gateways/status/check", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+
     if (response.status !== 200) {
       return { ok: false, message: "Unable to reach gateway." };
     }

--- a/install.sh
+++ b/install.sh
@@ -879,7 +879,7 @@ Access URLs:
 
 Auth:
 - AUTH_MODE=local
-- LOCAL_AUTH_TOKEN=$local_auth_token
+- LOCAL_AUTH_TOKEN is configured in .env / backend/.env (redacted)
 
 Stop stack:
   docker compose -f compose.yml --env-file .env down
@@ -948,7 +948,7 @@ Access URLs:
 
 Auth:
 - AUTH_MODE=local
-- LOCAL_AUTH_TOKEN=$local_auth_token
+- LOCAL_AUTH_TOKEN is configured in .env / backend/.env (redacted)
 
 If services were started by this script, logs are under:
 - $LOG_DIR/backend.log


### PR DESCRIPTION
## Summary

This hardens token handling paths to reduce accidental credential disclosure in logs, URLs, and UI payloads.

### What changed

- Redacted gateway secrets from read APIs:
  - `GatewayRead` now returns `has_token` instead of raw `token`.
  - CRUD gateway endpoints map DB model -> safe read model.
- Removed query-string token usage for gateway connectivity checks:
  - Added `POST /api/v1/gateways/status/check` (JSON body).
  - Frontend gateway connection checks now use this POST endpoint.
- Kept status checks usable without exposing tokens:
  - Server resolves and reuses saved gateway token by URL when caller omits token.
- Stopped URL token injection in gateway RPC URL builder:
  - auth token is kept in connect payload, not URL query.
- Installer output hardening:
  - `install.sh` no longer prints `LOCAL_AUTH_TOKEN` in bootstrap summary.
- Safer defaults/docs alignment:
  - `backend/.env.example` now sets secure header defaults (`nosniff`, `DENY`, `strict-origin-when-cross-origin`).
  - Security docs updated to reflect token redaction and POST status-check guidance.

## Validation

- Backend changed modules compile via `py_compile`.
- Frontend builds successfully (`npm run build`).

## Notes

- This PR focuses on token-leak reduction and safer defaults, without changing deployment topology or auth mode semantics.
