### PR TITLE
security: stop exposing gateway tokens in API responses

### DIFF
--- a/backend/app/schemas/gateways.py
+++ b/backend/app/schemas/gateways.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import field_validator
+from typing import Any
+
+from pydantic import field_validator, model_validator
 from sqlmodel import Field, SQLModel
 
 RUNTIME_ANNOTATION_TYPES = (datetime, UUID)
@@ -65,9 +67,22 @@ class GatewayRead(GatewayBase):
 
     id: UUID
     organization_id: UUID
-    token: str | None = None
+    has_token: bool = False
     created_at: datetime
     updated_at: datetime
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _compute_has_token(cls, values: Any, handler: Any) -> GatewayRead:
+        """Compute has_token from the ORM token field without exposing the raw value."""
+        model = handler(values)
+        token = (
+            getattr(values, "token", None)
+            if not isinstance(values, dict)
+            else values.get("token")
+        )
+        model.has_token = bool(token)
+        return model
 
 
 class GatewayTemplatesSyncError(SQLModel):


### PR DESCRIPTION
## Summary

Fixes a **critical** credential exposure where gateway authentication tokens were returned in plaintext in every API response:

- `GatewayRead` schema included `token: str | None` — any org admin could read raw gateway credentials via `GET /api/gateways`
- Tokens are also stored as plaintext in the database (unlike agent tokens which use PBKDF2-HMAC-SHA256), meaning a DB breach exposes every gateway credential immediately
- Stolen tokens grant full operator access to connected gateways (RCE via tool calls, data exfiltration, lateral movement)

### Fix
Replaced `token: str | None` with `has_token: bool` in `GatewayRead`, computed via a Pydantic `model_validator(mode='wrap')` that reads the ORM `token` field without serializing it. The token remains available server-side for outbound gateway RPC calls but is never sent to API clients.

**Note:** This PR addresses the API exposure. Encrypting tokens at rest (replacing plaintext DB storage) is a separate follow-up.

### Files Changed
- `backend/app/schemas/gateways.py` — `token: str | None` → `has_token: bool` + wrap validator

### CVSS
**9.1 Critical** — Network / Low complexity / Low privilege / No interaction / Scope changed

## Test plan
- [ ] `GET /api/gateways` returns `has_token: true/false` but no raw token value
- [ ] `GET /api/gateways/{id}` returns `has_token` without raw token
- [ ] `POST /api/gateways` with a token returns `has_token: true` in response
- [ ] `POST /api/gateways` without a token returns `has_token: false`
- [ ] `PATCH /api/gateways/{id}` with token update returns `has_token: true`
- [ ] Gateway outbound RPC calls still work (token available server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)