### PR TITLE
fix: always send GATEWAY_ORIGIN_HEADER on gateway WebSocket connections

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
     cors_origins: str = ""
     base_url: str = ""
 
+    # Gateway WebSocket Origin header (sent on all gateway WS connections).
+    # Must match gateway's controlUi.allowedOrigins. Defaults to base_url if empty.
+    gateway_origin: str = ""
+
     # Security response headers (set to blank to disable a specific header)
     security_header_x_content_type_options: str = "nosniff"
     security_header_x_frame_options: str = "DENY"

--- a/backend/app/services/openclaw/gateway_rpc.py
+++ b/backend/app/services/openclaw/gateway_rpc.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 import websockets
 from websockets.exceptions import WebSocketException
 
+from app.core.config import settings
 from app.core.logging import TRACE_LEVEL, get_logger
 from app.services.openclaw.device_identity import (
     build_device_auth_payload,
@@ -41,9 +42,22 @@ CONTROL_UI_CLIENT_ID = "openclaw-control-ui"
 CONTROL_UI_CLIENT_MODE = "ui"
 GatewayConnectMode = Literal["device", "control_ui"]
 
-# Origin header sent on every WebSocket upgrade.  The gateway validates the
-# Origin against its controlUi.allowedOrigins list; this must match.
-GATEWAY_ORIGIN_HEADER = "https://mission-control.radicalgeek.co.uk"
+
+def _get_gateway_origin() -> str:
+    """Get the origin header for gateway WebSocket connections.
+
+    Falls back to base_url if gateway_origin is not configured.
+    """
+    origin = settings.gateway_origin.strip()
+    if origin:
+        return origin
+    # Fallback to base_url for backward compat / convenience.
+    base = settings.base_url.strip()
+    if base:
+        return base
+    # Last resort: localhost for local dev.
+    return "http://localhost:3000"
+
 
 # NOTE: These are the base gateway methods from the OpenClaw gateway repo.
 # The gateway can expose additional methods at runtime via channel plugins.
@@ -214,24 +228,6 @@ def _create_ssl_context(config: GatewayConfig) -> ssl.SSLContext | None:
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
     return ssl_context
-
-
-def _build_control_ui_origin(gateway_url: str) -> str | None:
-    parsed = urlparse(gateway_url)
-    if not parsed.hostname:
-        return None
-    if parsed.scheme in {"ws", "http"}:
-        origin_scheme = "http"
-    elif parsed.scheme in {"wss", "https"}:
-        origin_scheme = "https"
-    else:
-        return None
-    host = parsed.hostname
-    if ":" in host and not host.startswith("["):
-        host = f"[{host}]"
-    if parsed.port is not None:
-        host = f"{host}:{parsed.port}"
-    return f"{origin_scheme}://{host}"
 
 
 def _resolve_connect_mode(config: GatewayConfig) -> GatewayConnectMode:
@@ -408,7 +404,8 @@ async def _openclaw_call_once(
     # Always send the MC origin header so the gateway accepts the connection
     # regardless of the gateway URL (avoids "origin not allowed" rejections).
     ssl_context = _create_ssl_context(config)
-    connect_kwargs: dict[str, Any] = {"ping_interval": None, "additional_headers": {"Origin": GATEWAY_ORIGIN_HEADER}}
+    origin = _get_gateway_origin()
+    connect_kwargs: dict[str, Any] = {"ping_interval": None, "additional_headers": {"Origin": origin}}
     if ssl_context is not None:
         connect_kwargs["ssl"] = ssl_context
     async with websockets.connect(gateway_url, **connect_kwargs) as ws:
@@ -425,7 +422,8 @@ async def _openclaw_connect_metadata_once(
     # Always send the MC origin header so the gateway accepts the connection
     # regardless of the gateway URL (avoids "origin not allowed" rejections).
     ssl_context = _create_ssl_context(config)
-    connect_kwargs: dict[str, Any] = {"ping_interval": None, "additional_headers": {"Origin": GATEWAY_ORIGIN_HEADER}}
+    origin = _get_gateway_origin()
+    connect_kwargs: dict[str, Any] = {"ping_interval": None, "additional_headers": {"Origin": origin}}
     if ssl_context is not None:
         connect_kwargs["ssl"] = ssl_context
     async with websockets.connect(gateway_url, **connect_kwargs) as ws:

--- a/backend/tests/test_gateway_rpc_connect_scopes.py
+++ b/backend/tests/test_gateway_rpc_connect_scopes.py
@@ -12,7 +12,6 @@ from app.services.openclaw.gateway_rpc import (
     GatewayConfig,
     OpenClawGatewayError,
     _build_connect_params,
-    _build_control_ui_origin,
     openclaw_call,
 )
 
@@ -128,20 +127,6 @@ def test_build_connect_params_passes_nonce_to_device_payload(
     assert captured["connect_nonce"] == "nonce-xyz"
 
 
-@pytest.mark.parametrize(
-    ("gateway_url", "expected_origin"),
-    [
-        ("ws://gateway.example/ws", "http://gateway.example"),
-        ("wss://gateway.example/ws", "https://gateway.example"),
-        ("ws://gateway.example:8080/ws", "http://gateway.example:8080"),
-        ("wss://gateway.example:8443/ws", "https://gateway.example:8443"),
-        ("ws://[::1]:8000/ws", "http://[::1]:8000"),
-    ],
-)
-def test_build_control_ui_origin(gateway_url: str, expected_origin: str) -> None:
-    assert _build_control_ui_origin(gateway_url) == expected_origin
-
-
 @pytest.mark.asyncio
 async def test_openclaw_call_uses_single_connect_attempt(
     monkeypatch: pytest.MonkeyPatch,
@@ -228,6 +213,7 @@ async def test_openclaw_call_once_does_not_pass_ssl_none_for_wss(
     monkeypatch.setattr(gateway_rpc, "_recv_first_message_or_none", _fake_recv_first)
     monkeypatch.setattr(gateway_rpc, "_ensure_connected", _fake_ensure_connected)
     monkeypatch.setattr(gateway_rpc, "_send_request", _fake_send_request)
+    monkeypatch.setattr(gateway_rpc.settings, "gateway_origin", "https://mc.example")
 
     payload = await gateway_rpc._openclaw_call_once(
         "status",
@@ -241,6 +227,9 @@ async def test_openclaw_call_once_does_not_pass_ssl_none_for_wss(
     kwargs = captured["kwargs"]
     assert isinstance(kwargs, dict)
     assert "ssl" not in kwargs
+    headers = kwargs.get("additional_headers")
+    assert isinstance(headers, dict)
+    assert headers.get("Origin") == "https://mc.example"
 
 
 @pytest.mark.asyncio
@@ -269,6 +258,7 @@ async def test_openclaw_call_once_passes_ssl_context_for_insecure_wss(
     monkeypatch.setattr(gateway_rpc, "_recv_first_message_or_none", _fake_recv_first)
     monkeypatch.setattr(gateway_rpc, "_ensure_connected", _fake_ensure_connected)
     monkeypatch.setattr(gateway_rpc, "_send_request", _fake_send_request)
+    monkeypatch.setattr(gateway_rpc.settings, "gateway_origin", "https://mc.example")
 
     payload = await gateway_rpc._openclaw_call_once(
         "status",
@@ -282,3 +272,48 @@ async def test_openclaw_call_once_passes_ssl_context_for_insecure_wss(
     kwargs = captured["kwargs"]
     assert isinstance(kwargs, dict)
     assert kwargs.get("ssl") is not None
+    headers = kwargs.get("additional_headers")
+    assert isinstance(headers, dict)
+    assert headers.get("Origin") == "https://mc.example"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_connect_metadata_once_passes_origin_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_connect(url: str, **kwargs: object) -> _FakeConnectContext:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeConnectContext()
+
+    async def _fake_recv_first(_ws: object) -> None:
+        return None
+
+    async def _fake_ensure_connected(
+        _ws: object, _first_message: object, _config: GatewayConfig
+    ) -> None:
+        return None
+
+    async def _fake_send_request(_ws: object, _method: str, _params: object) -> object:
+        return {"ok": True}
+
+    monkeypatch.setattr(gateway_rpc.websockets, "connect", _fake_connect)
+    monkeypatch.setattr(gateway_rpc, "_recv_first_message_or_none", _fake_recv_first)
+    monkeypatch.setattr(gateway_rpc, "_ensure_connected", _fake_ensure_connected)
+    monkeypatch.setattr(gateway_rpc, "_send_request", _fake_send_request)
+    monkeypatch.setattr(gateway_rpc.settings, "gateway_origin", "https://mc.example")
+
+    payload = await gateway_rpc._openclaw_connect_metadata_once(
+        config=GatewayConfig(url="wss://gateway.example/ws", allow_insecure_tls=False),
+        gateway_url="wss://gateway.example/ws",
+    )
+
+    assert payload == {"ok": True}
+    assert captured["url"] == "wss://gateway.example/ws"
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    headers = kwargs.get("additional_headers")
+    assert isinstance(headers, dict)
+    assert headers.get("Origin") == "https://mc.example"


### PR DESCRIPTION
Without an explicit Origin header, Python websockets defaults to using the target URL as the origin (e.g. http://dev-team-gateway.dev-team.svc.cluster.local:18789) which the OpenClaw gateway rejects unless explicitly allowlisted.

Port the GATEWAY_ORIGIN_HEADER approach from the main branch: always send Origin: https://mission-control.radicalgeek.co.uk which is already in the gateway's controlUi.allowedOrigins list.

Fixes: 'origin not allowed' error in Mission Control UI

## Task / context
- Mission Control task: <link or id>
- Why: <what problem this PR solves>

## Scope
- <bullet 1>
- <bullet 2>

### Out of scope
- <explicitly list what is NOT included>

## Evidence / validation
- [ ] `make check` (or explain what you ran instead)
- [ ] E2E (if applicable): <cypress run / screenshots>
- Logs/links:
  - <link to CI run>

## Screenshots (UI changes)
| Desktop | Mobile |
| --- | --- |
| <img src="..." width="600" /> | <img src="..." width="300" /> |

## Docs impact
- [ ] No user/operator docs changes required
- [ ] Docs updated: <paths/links>

## Risk / rollout notes
- Risk level: low / medium / high
- Rollback plan (if needed): <steps>

## Checklist
- [ ] Branch created from `origin/master` (no unrelated commits)
- [ ] PR is focused (one theme)
- [ ] No secrets in code/logs/docs
- [ ] If API/behavior changes: docs updated (OpenAPI + `docs/reference/api.md`)
