### PR TITLE
docs: add Copilot instruction files

### DIFF
--- a/.github/instructions/backend-python-changes.instructions.md
+++ b/.github/instructions/backend-python-changes.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Use when changing FastAPI routes, backend services, SQLModel models, Pydantic schemas, or backend pytest coverage. Covers strict typing, keeping business logic out of route handlers, and updating tests with behavior changes."
+name: "Backend Python Changes"
+applyTo: "backend/app/**/*.py, backend/tests/**/*.py"
+---
+# Backend Python Changes
+
+- Keep contract changes aligned across routes, schemas, services, and models instead of patching only one layer.
+- Prefer business logic in `backend/app/services/` or existing helper layers rather than expanding route handlers with workflow logic.
+- Preserve strict typing: avoid introducing `Any`, loosely typed payload dictionaries, or untyped helper returns when a schema or model type fits.
+- When behavior changes, add or update focused pytest coverage in `backend/tests/`, especially for API, auth, security, or regression-sensitive flows.
+- Keep edits narrow and consistent with existing module boundaries, then run targeted backend checks when practical and state clearly if they were not run.

--- a/.github/instructions/docs-writing.instructions.md
+++ b/.github/instructions/docs-writing.instructions.md
@@ -1,0 +1,13 @@
+---
+description: "Use when writing or editing Markdown documentation under docs. Covers sentence-case headings, concrete examples, procedure structure, and clear warnings for risky operations."
+name: "Docs Writing"
+applyTo: "docs/**/*.md, *.md"
+---
+# Docs Writing
+
+- Keep docs concrete and scannable: prefer commands, examples, expected outcomes, short sections, and flat bullet lists over long narrative prose.
+- Follow the repo docs style guide with sentence-case headings and fenced code blocks that include a language such as `bash`, `yaml`, or `json`.
+- When documenting a procedure, structure it around prerequisites, steps, verification, and troubleshooting when that pattern fits the task.
+- If behavior is uncertain, do not invent it. Link or point to the source of truth and mark the item for verification.
+- Clearly label destructive, security-sensitive, or irreversible operations with a simple note or warning callout.
+- Prefer placing new content in the most specific existing docs section under `docs/` instead of creating overlapping top-level guides.

--- a/.github/instructions/generated-api-client.instructions.md
+++ b/.github/instructions/generated-api-client.instructions.md
@@ -1,0 +1,13 @@
+---
+description: "Use when working on frontend API calls, Orval-generated files, frontend/orval.config.ts, frontend/src/api/mutator.ts, or backend schema changes that affect the generated client. Covers regeneration, where to make source changes, and when to avoid hand-editing generated output."
+name: "Generated API Client"
+applyTo: "frontend/src/api/generated/**"
+---
+# Generated API Client
+
+- Treat `frontend/src/api/generated/` as generated output. Do not hand-edit files there unless the user explicitly asks for a generated-code workaround.
+- Make API behavior changes in the source of truth instead: backend routes and schemas, `frontend/orval.config.ts`, or `frontend/src/api/mutator.ts`.
+- After contract changes, regenerate the client with `make api-gen` from the repo root or `npm run api:gen` from `frontend/`.
+- If regeneration cannot be run in the current environment, state that clearly and prefer changes in non-generated wrappers or source files over manual edits in generated output.
+
+Use this instruction for frontend API tasks even when the immediate file being edited is not under `frontend/src/api/generated/`.


### PR DESCRIPTION
## Summary
- add a backend Python instruction for FastAPI/service/schema/test changes
- add a generated API client instruction for Orval and frontend API workflow changes
- add a docs writing instruction for docs and top-level Markdown files

## Testing
- not run (instruction files only)