### PR TITLE
security: proxy /api and /healthz to backend via Next.js rewrites

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,6 +14,18 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://backend:8000/api/:path*",
+      },
+      {
+        source: "/healthz",
+        destination: "http://backend:8000/healthz",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds Next.js rewrites so the frontend proxies `/api/*` and `/healthz` requests to the backend over the internal Docker network.

## Why

When the frontend is the only service exposed externally (e.g. behind a Cloudflare Tunnel or a single reverse proxy on port 3000), browser requests to `/api/*` have no route to the backend. The current options are to expose the backend port publicly or set up a second ingress, both of which leak internal services onto the network unnecessarily.

With these rewrites the frontend forwards API traffic to `http://backend:8000` inside the compose network, so the backend never needs to be reachable from outside.

## Changes

- `frontend/next.config.ts`: added `rewrites()` mapping `/api/:path*` and `/healthz` to the backend service.

## Test plan

- [ ] `docker compose up --build` with `NEXT_PUBLIC_API_URL` set to the frontend origin
- [ ] Verify `/api/v1/users/me` returns JSON, not the frontend HTML
- [ ] Verify `/healthz` proxies correctly
- [ ] Confirm no change in behaviour when accessing the backend directly on its own port