### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -58,6 +58,11 @@ DEFAULT_INSTALLER_SKILL_PACKS = (
         "ai-marketing-skills",
         "Marketing frameworks that AI actually executes. Use for Claude Code, OpenClaw, etc.",
     ),
+    (
+        "MiniMax-AI/cli",
+        "mmx-cli",
+        "Generate text, images, video, speech, and music via MiniMax AI platform.",
+    ),
 )
 ADMIN_ROLES = {"owner", "admin"}
 ROLE_RANK = {"member": 0, "admin": 1, "owner": 2}


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `DEFAULT_INSTALLER_SKILL_PACKS` in `backend/app/services/organizations.py` so the mmx-cli skill is provisioned out of the box for every new organization
- Users can sync the pack from the Skills Marketplace UI — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**5 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- New organization provisioning includes the mmx-cli pack in the default skill pack list
- Syncing the pack discovers and registers the mmx-cli skill in the marketplace
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal