### PR TITLE
Add first-class workflow runs and board UI visibility

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1,0 +1,393 @@
+"""Workflow definition/run/step endpoints."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import col
+
+from app.api.deps import (
+    ActorContext,
+    get_board_for_actor_read,
+    get_board_for_actor_write,
+    require_user_or_agent,
+)
+from app.core.time import utcnow
+from app.db import crud
+from app.db.pagination import paginate
+from app.db.session import get_session
+from app.models.activity_events import ActivityEvent
+from app.models.boards import Board
+from app.models.workflows import WorkflowDefinition, WorkflowRun, WorkflowStep, WorkflowStepEvent
+from app.schemas.common import OkResponse
+from app.schemas.pagination import DefaultLimitOffsetPage
+from app.schemas.workflows import (
+    WorkflowDefinitionCreate,
+    WorkflowDefinitionRead,
+    WorkflowDefinitionUpdate,
+    WorkflowRunCreate,
+    WorkflowRunRead,
+    WorkflowRunSummary,
+    WorkflowRunUpdate,
+    WorkflowStepRead,
+    WorkflowStepUpdate,
+)
+from app.services.activity_log import record_activity
+
+if False:  # pragma: no cover
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+router = APIRouter(prefix="/boards/{board_id}", tags=["workflows"])
+
+SESSION_DEP = Depends(get_session)
+BOARD_READ_DEP = Depends(get_board_for_actor_read)
+BOARD_WRITE_DEP = Depends(get_board_for_actor_write)
+ACTOR_DEP = Depends(require_user_or_agent)
+
+
+def _step_dep_ids(step: WorkflowStep) -> list[UUID]:
+    raw = step.depends_on_step_ids_json or []
+    output: list[UUID] = []
+    for item in raw:
+        try:
+            output.append(UUID(str(item)))
+        except ValueError:
+            continue
+    return output
+
+
+def _step_read(step: WorkflowStep) -> WorkflowStepRead:
+    return WorkflowStepRead(
+        id=step.id,
+        workflow_run_id=step.workflow_run_id,
+        step_key=step.step_key,
+        title=step.title,
+        step_type=step.step_type,
+        status=step.status,
+        assigned_user_id=step.assigned_user_id,
+        assigned_agent_id=step.assigned_agent_id,
+        task_id=step.task_id,
+        approval_id=step.approval_id,
+        depends_on_step_ids=_step_dep_ids(step),
+        instructions=step.instructions,
+        input_json=step.input_json,
+        output_json=step.output_json,
+        due_at=step.due_at,
+        sort_order=step.sort_order,
+        started_at=step.started_at,
+        completed_at=step.completed_at,
+        created_at=step.created_at,
+        updated_at=step.updated_at,
+    )
+
+
+async def _run_steps(session: AsyncSession, *, run_id: UUID) -> list[WorkflowStep]:
+    return (
+        await WorkflowStep.objects.filter_by(workflow_run_id=run_id)
+        .order_by(col(WorkflowStep.sort_order).asc(), col(WorkflowStep.created_at).asc())
+        .all(session)
+    )
+
+
+async def _run_read(session: AsyncSession, run: WorkflowRun) -> WorkflowRunRead:
+    return WorkflowRunRead(
+        id=run.id,
+        board_id=run.board_id,
+        workflow_definition_id=run.workflow_definition_id,
+        source_task_id=run.source_task_id,
+        title=run.title,
+        status=run.status,
+        current_step_key=run.current_step_key,
+        created_by_user_id=run.created_by_user_id,
+        created_by_agent_id=run.created_by_agent_id,
+        context_json=run.context_json,
+        result_json=run.result_json,
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+        steps=[_step_read(step) for step in await _run_steps(session, run_id=run.id)],
+    )
+
+
+def _run_summary(run: WorkflowRun, *, steps: list[WorkflowStep]) -> WorkflowRunSummary:
+    return WorkflowRunSummary(
+        id=run.id,
+        title=run.title,
+        status=run.status,
+        current_step_key=run.current_step_key,
+        source_task_id=run.source_task_id,
+        waiting_step_count=sum(1 for step in steps if step.status in {"waiting_human", "waiting_approval"}),
+        approval_step_count=sum(1 for step in steps if step.step_type == "approval"),
+        human_step_count=sum(1 for step in steps if step.step_type == "human_task"),
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+    )
+
+
+async def _record_workflow_event(
+    session: AsyncSession,
+    *,
+    run: WorkflowRun,
+    actor: ActorContext,
+    event_type: str,
+    message: str,
+    step: WorkflowStep | None = None,
+    payload_json: dict[str, object] | None = None,
+) -> None:
+    workflow_event = WorkflowStepEvent(
+        workflow_run_id=run.id,
+        workflow_step_id=step.id if step else None,
+        actor_user_id=actor.user.id if actor.actor_type == "user" and actor.user else None,
+        actor_agent_id=actor.agent.id if actor.actor_type == "agent" and actor.agent else None,
+        event_type=event_type,
+        payload_json=payload_json,
+    )
+    session.add(workflow_event)
+    record_activity(
+        session,
+        event_type=event_type,
+        message=message,
+        agent_id=workflow_event.actor_agent_id,
+        task_id=run.source_task_id,
+        board_id=run.board_id,
+    )
+
+
+@router.get("/workflows", response_model=DefaultLimitOffsetPage[WorkflowDefinitionRead])
+async def list_workflow_definitions(
+    board: Board = BOARD_READ_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+):
+    statement = (
+        WorkflowDefinition.objects.filter(
+            (col(WorkflowDefinition.organization_id) == board.organization_id)
+            & ((col(WorkflowDefinition.board_id) == board.id) | (col(WorkflowDefinition.board_id).is_(None)))
+        )
+        .order_by(col(WorkflowDefinition.created_at).desc())
+        .statement
+    )
+    return await paginate(session, statement)
+
+
+@router.post("/workflows", response_model=WorkflowDefinitionRead)
+async def create_workflow_definition(
+    payload: WorkflowDefinitionCreate,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+) -> WorkflowDefinition:
+    workflow = WorkflowDefinition.model_validate(
+        {
+            **payload.model_dump(),
+            "organization_id": board.organization_id,
+            "board_id": payload.board_id if payload.board_id is not None else board.id,
+        }
+    )
+    return await crud.create(session, WorkflowDefinition, **workflow.model_dump())
+
+
+@router.patch("/workflows/{workflow_id}", response_model=WorkflowDefinitionRead)
+async def update_workflow_definition(
+    workflow_id: UUID,
+    payload: WorkflowDefinitionUpdate,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+) -> WorkflowDefinition:
+    workflow = await WorkflowDefinition.objects.by_id(workflow_id).first(session)
+    if workflow is None or workflow.organization_id != board.organization_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    updates = payload.model_dump(exclude_unset=True)
+    crud.apply_updates(workflow, updates)
+    workflow.updated_at = utcnow()
+    return await crud.save(session, workflow)
+
+
+@router.get("/workflow-runs", response_model=DefaultLimitOffsetPage[WorkflowRunSummary])
+async def list_workflow_runs(
+    board: Board = BOARD_READ_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+):
+    statement = (
+        WorkflowRun.objects.filter_by(board_id=board.id)
+        .order_by(col(WorkflowRun.created_at).desc())
+        .statement
+    )
+
+    async def _transform(items: list[object]) -> list[WorkflowRunSummary]:
+        runs = [item for item in items if isinstance(item, WorkflowRun)]
+        summaries: list[WorkflowRunSummary] = []
+        for run in runs:
+            summaries.append(_run_summary(run, steps=await _run_steps(session, run_id=run.id)))
+        return summaries
+
+    return await paginate(session, statement, transformer=_transform)
+
+
+@router.post("/workflow-runs", response_model=WorkflowRunRead)
+async def create_workflow_run(
+    payload: WorkflowRunCreate,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    actor: ActorContext = ACTOR_DEP,
+) -> WorkflowRunRead:
+    workflow_definition = None
+    if payload.workflow_definition_id is not None:
+        workflow_definition = await WorkflowDefinition.objects.by_id(payload.workflow_definition_id).first(session)
+        if workflow_definition is None or workflow_definition.organization_id != board.organization_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="workflow definition not found")
+    run = WorkflowRun(
+        board_id=board.id,
+        workflow_definition_id=payload.workflow_definition_id,
+        source_task_id=payload.source_task_id,
+        title=payload.title.strip(),
+        status=payload.status,
+        current_step_key=payload.current_step_key,
+        context_json=payload.context_json,
+        result_json=payload.result_json,
+        created_by_user_id=actor.user.id if actor.actor_type == "user" and actor.user else None,
+        created_by_agent_id=actor.agent.id if actor.actor_type == "agent" and actor.agent else None,
+        started_at=utcnow() if payload.status == "running" else None,
+    )
+    session.add(run)
+    await session.flush()
+    created_steps: list[WorkflowStep] = []
+    for index, step_payload in enumerate(payload.steps):
+        step = WorkflowStep(
+            workflow_run_id=run.id,
+            step_key=step_payload.step_key,
+            title=step_payload.title,
+            step_type=step_payload.step_type,
+            status=step_payload.status,
+            assigned_user_id=step_payload.assigned_user_id,
+            assigned_agent_id=step_payload.assigned_agent_id,
+            task_id=step_payload.task_id,
+            approval_id=step_payload.approval_id,
+            depends_on_step_ids_json=[str(value) for value in step_payload.depends_on_step_ids],
+            instructions=step_payload.instructions,
+            input_json=step_payload.input_json,
+            output_json=step_payload.output_json,
+            due_at=step_payload.due_at,
+            sort_order=step_payload.sort_order if step_payload.sort_order else index,
+            started_at=utcnow() if step_payload.status == "running" else None,
+            completed_at=utcnow() if step_payload.status == "completed" else None,
+        )
+        session.add(step)
+        created_steps.append(step)
+    await _record_workflow_event(
+        session,
+        run=run,
+        actor=actor,
+        event_type="workflow.run.created",
+        message=f"Workflow run created: {run.title}.",
+        payload_json={
+            "workflow_definition_id": str(workflow_definition.id) if workflow_definition else None,
+            "step_count": len(created_steps),
+        },
+    )
+    await session.commit()
+    await session.refresh(run)
+    return await _run_read(session, run)
+
+
+@router.get("/workflow-runs/{run_id}", response_model=WorkflowRunRead)
+async def get_workflow_run(
+    run_id: UUID,
+    board: Board = BOARD_READ_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+) -> WorkflowRunRead:
+    run = await WorkflowRun.objects.by_id(run_id).first(session)
+    if run is None or run.board_id != board.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return await _run_read(session, run)
+
+
+@router.patch("/workflow-runs/{run_id}", response_model=WorkflowRunRead)
+async def update_workflow_run(
+    run_id: UUID,
+    payload: WorkflowRunUpdate,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    actor: ActorContext = ACTOR_DEP,
+) -> WorkflowRunRead:
+    run = await WorkflowRun.objects.by_id(run_id).first(session)
+    if run is None or run.board_id != board.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    updates = payload.model_dump(exclude_unset=True)
+    previous_status = run.status
+    crud.apply_updates(run, updates)
+    if "status" in updates and updates["status"] == "completed" and run.completed_at is None:
+        run.completed_at = utcnow()
+    if "status" in updates and updates["status"] == "running" and run.started_at is None:
+        run.started_at = utcnow()
+    run.updated_at = utcnow()
+    session.add(run)
+    await _record_workflow_event(
+        session,
+        run=run,
+        actor=actor,
+        event_type="workflow.run.updated",
+        message=f"Workflow run updated: {run.title} ({previous_status} -> {run.status}).",
+        payload_json={"previous_status": previous_status, "status": run.status},
+    )
+    await session.commit()
+    await session.refresh(run)
+    return await _run_read(session, run)
+
+
+@router.patch("/workflow-steps/{step_id}", response_model=WorkflowStepRead)
+async def update_workflow_step(
+    step_id: UUID,
+    payload: WorkflowStepUpdate,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    actor: ActorContext = ACTOR_DEP,
+) -> WorkflowStepRead:
+    step = await WorkflowStep.objects.by_id(step_id).first(session)
+    if step is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    run = await WorkflowRun.objects.by_id(step.workflow_run_id).first(session)
+    if run is None or run.board_id != board.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    previous_status = step.status
+    updates = payload.model_dump(exclude_unset=True)
+    crud.apply_updates(step, updates)
+    if "status" in updates and updates["status"] == "running" and step.started_at is None:
+        step.started_at = utcnow()
+    if "status" in updates and updates["status"] == "completed" and step.completed_at is None:
+        step.completed_at = utcnow()
+    step.updated_at = utcnow()
+    session.add(step)
+    await _record_workflow_event(
+        session,
+        run=run,
+        step=step,
+        actor=actor,
+        event_type="workflow.step.updated",
+        message=f"Workflow step updated: {step.title} ({previous_status} -> {step.status}).",
+        payload_json={"previous_status": previous_status, "status": step.status, "step_key": step.step_key},
+    )
+    await session.commit()
+    await session.refresh(step)
+    return _step_read(step)
+
+
+@router.delete("/workflow-runs/{run_id}", response_model=OkResponse)
+async def delete_workflow_run(
+    run_id: UUID,
+    board: Board = BOARD_WRITE_DEP,
+    session: AsyncSession = SESSION_DEP,
+    _actor: ActorContext = ACTOR_DEP,
+) -> OkResponse:
+    run = await WorkflowRun.objects.by_id(run_id).first(session)
+    if run is None or run.board_id != board.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    await crud.delete_where(session, WorkflowStepEvent, col(WorkflowStepEvent.workflow_run_id) == run.id)
+    await crud.delete_where(session, WorkflowStep, col(WorkflowStep.workflow_run_id) == run.id)
+    await crud.delete(session, run)
+    return OkResponse()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.api.tags import router as tags_router
 from app.api.task_custom_fields import router as task_custom_fields_router
 from app.api.tasks import router as tasks_router
 from app.api.users import router as users_router
+from app.api.workflows import router as workflows_router
 from app.core.config import settings
 from app.core.error_handling import install_error_handling
 from app.core.logging import configure_logging, get_logger
@@ -125,6 +126,10 @@ OPENAPI_TAGS = [
     {
         "name": "tags",
         "description": "Tag catalog and task-tag association management endpoints.",
+    },
+    {
+        "name": "workflows",
+        "description": "Workflow definitions, runs, steps, and lifecycle tracking endpoints.",
     },
     {
         "name": "users",
@@ -555,6 +560,7 @@ api_v1.include_router(board_webhooks_router)
 api_v1.include_router(board_onboarding_router)
 api_v1.include_router(approvals_router)
 api_v1.include_router(tasks_router)
+api_v1.include_router(workflows_router)
 api_v1.include_router(task_custom_fields_router)
 api_v1.include_router(tags_router)
 api_v1.include_router(users_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,6 +29,7 @@ from app.models.task_dependencies import TaskDependency
 from app.models.task_fingerprints import TaskFingerprint
 from app.models.tasks import Task
 from app.models.users import User
+from app.models.workflows import WorkflowDefinition, WorkflowRun, WorkflowStep, WorkflowStepEvent
 
 __all__ = [
     "ActivityEvent",
@@ -60,4 +61,8 @@ __all__ = [
     "Tag",
     "TagAssignment",
     "User",
+    "WorkflowDefinition",
+    "WorkflowRun",
+    "WorkflowStep",
+    "WorkflowStepEvent",
 ]

--- a/backend/app/models/workflows.py
+++ b/backend/app/models/workflows.py
@@ -1,0 +1,102 @@
+"""Workflow definition/run/step models for first-class workflow tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field
+
+from app.core.time import utcnow
+from app.models.tenancy import TenantScoped
+
+RUNTIME_ANNOTATION_TYPES = (datetime,)
+
+
+class WorkflowDefinition(TenantScoped, table=True):
+    """Repeatable workflow template scoped to an organization and optional board."""
+
+    __tablename__ = "workflow_definitions"  # pyright: ignore[reportAssignmentType]
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    organization_id: UUID = Field(foreign_key="organizations.id", index=True)
+    board_id: UUID | None = Field(default=None, foreign_key="boards.id", index=True)
+    name: str
+    slug: str = Field(index=True)
+    description: str | None = None
+    version: int = Field(default=1)
+    status: str = Field(default="draft", index=True)
+    trigger_mode: str = Field(default="manual", index=True)
+    step_graph_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    default_policy_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
+
+
+class WorkflowRun(TenantScoped, table=True):
+    """Execution instance for a workflow definition."""
+
+    __tablename__ = "workflow_runs"  # pyright: ignore[reportAssignmentType]
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    board_id: UUID = Field(foreign_key="boards.id", index=True)
+    workflow_definition_id: UUID | None = Field(
+        default=None,
+        foreign_key="workflow_definitions.id",
+        index=True,
+    )
+    source_task_id: UUID | None = Field(default=None, foreign_key="tasks.id", index=True)
+    title: str
+    status: str = Field(default="pending", index=True)
+    current_step_key: str | None = Field(default=None, index=True)
+    created_by_user_id: UUID | None = Field(default=None, foreign_key="users.id", index=True)
+    created_by_agent_id: UUID | None = Field(default=None, foreign_key="agents.id", index=True)
+    context_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    result_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
+
+
+class WorkflowStep(TenantScoped, table=True):
+    """Materialized step belonging to a workflow run."""
+
+    __tablename__ = "workflow_steps"  # pyright: ignore[reportAssignmentType]
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    workflow_run_id: UUID = Field(foreign_key="workflow_runs.id", index=True)
+    step_key: str = Field(index=True)
+    title: str
+    step_type: str = Field(default="agent_task", index=True)
+    status: str = Field(default="pending", index=True)
+    assigned_user_id: UUID | None = Field(default=None, foreign_key="users.id", index=True)
+    assigned_agent_id: UUID | None = Field(default=None, foreign_key="agents.id", index=True)
+    task_id: UUID | None = Field(default=None, foreign_key="tasks.id", index=True)
+    approval_id: UUID | None = Field(default=None, foreign_key="approvals.id", index=True)
+    depends_on_step_ids_json: list[str] | None = Field(default=None, sa_column=Column(JSON))
+    instructions: str | None = None
+    input_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    output_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    due_at: datetime | None = None
+    sort_order: int = Field(default=0)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
+
+
+class WorkflowStepEvent(TenantScoped, table=True):
+    """Structured audit event for workflow runs and steps."""
+
+    __tablename__ = "workflow_step_events"  # pyright: ignore[reportAssignmentType]
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    workflow_run_id: UUID = Field(foreign_key="workflow_runs.id", index=True)
+    workflow_step_id: UUID | None = Field(default=None, foreign_key="workflow_steps.id", index=True)
+    actor_user_id: UUID | None = Field(default=None, foreign_key="users.id", index=True)
+    actor_agent_id: UUID | None = Field(default=None, foreign_key="agents.id", index=True)
+    event_type: str = Field(index=True)
+    payload_json: dict[str, object] | None = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=utcnow)

--- a/backend/app/schemas/view_models.py
+++ b/backend/app/schemas/view_models.py
@@ -14,6 +14,7 @@ from app.schemas.board_memory import BoardMemoryRead
 from app.schemas.boards import BoardRead
 from app.schemas.tags import TagRef
 from app.schemas.tasks import TaskRead
+from app.schemas.workflows import WorkflowRunSummary
 
 RUNTIME_ANNOTATION_TYPES = (
     datetime,
@@ -24,6 +25,7 @@ RUNTIME_ANNOTATION_TYPES = (
     BoardMemoryRead,
     BoardRead,
     TagRef,
+    WorkflowRunSummary,
 )
 
 
@@ -44,6 +46,7 @@ class BoardSnapshot(SQLModel):
     approvals: list[ApprovalRead]
     chat_messages: list[BoardMemoryRead]
     pending_approvals_count: int = 0
+    workflow_runs: list[WorkflowRunSummary] = Field(default_factory=list)
 
 
 class BoardGroupTaskSummary(SQLModel):

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -1,0 +1,197 @@
+"""Schemas for workflow definitions, runs, and steps."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import model_validator
+from sqlmodel import Field, SQLModel
+
+WorkflowDefinitionStatus = Literal["draft", "active", "archived"]
+WorkflowTriggerMode = Literal["manual", "task_status", "webhook", "schedule", "api"]
+WorkflowRunStatus = Literal[
+    "pending",
+    "running",
+    "blocked",
+    "waiting_human",
+    "waiting_approval",
+    "completed",
+    "failed",
+    "canceled",
+]
+WorkflowStepType = Literal[
+    "agent_task",
+    "human_task",
+    "approval",
+    "notification",
+    "wait",
+    "decision",
+    "subworkflow",
+]
+WorkflowStepStatus = Literal[
+    "pending",
+    "ready",
+    "running",
+    "blocked",
+    "waiting_human",
+    "waiting_approval",
+    "completed",
+    "failed",
+    "skipped",
+    "canceled",
+]
+RUNTIME_ANNOTATION_TYPES = (datetime, UUID)
+
+
+class WorkflowDefinitionBase(SQLModel):
+    name: str
+    slug: str
+    description: str | None = None
+    version: int = 1
+    status: WorkflowDefinitionStatus = "draft"
+    trigger_mode: WorkflowTriggerMode = "manual"
+    step_graph_json: dict[str, object] | None = None
+    default_policy_json: dict[str, object] | None = None
+
+    @model_validator(mode="after")
+    def validate_strings(self) -> Self:
+        self.name = self.name.strip()
+        self.slug = self.slug.strip()
+        if not self.name:
+            raise ValueError("name is required")
+        if not self.slug:
+            raise ValueError("slug is required")
+        if self.description is not None:
+            self.description = self.description.strip() or None
+        return self
+
+
+class WorkflowDefinitionCreate(WorkflowDefinitionBase):
+    board_id: UUID | None = None
+
+
+class WorkflowDefinitionUpdate(SQLModel):
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+    version: int | None = None
+    status: WorkflowDefinitionStatus | None = None
+    trigger_mode: WorkflowTriggerMode | None = None
+    step_graph_json: dict[str, object] | None = None
+    default_policy_json: dict[str, object] | None = None
+
+
+class WorkflowDefinitionRead(WorkflowDefinitionBase):
+    id: UUID
+    organization_id: UUID
+    board_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkflowStepCreate(SQLModel):
+    step_key: str
+    title: str
+    step_type: WorkflowStepType = "agent_task"
+    status: WorkflowStepStatus = "pending"
+    assigned_user_id: UUID | None = None
+    assigned_agent_id: UUID | None = None
+    task_id: UUID | None = None
+    approval_id: UUID | None = None
+    depends_on_step_ids: list[UUID] = Field(default_factory=list)
+    instructions: str | None = None
+    input_json: dict[str, object] | None = None
+    output_json: dict[str, object] | None = None
+    due_at: datetime | None = None
+    sort_order: int = 0
+
+
+class WorkflowStepUpdate(SQLModel):
+    status: WorkflowStepStatus | None = None
+    assigned_user_id: UUID | None = None
+    assigned_agent_id: UUID | None = None
+    task_id: UUID | None = None
+    approval_id: UUID | None = None
+    instructions: str | None = None
+    input_json: dict[str, object] | None = None
+    output_json: dict[str, object] | None = None
+    due_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class WorkflowStepRead(SQLModel):
+    id: UUID
+    workflow_run_id: UUID
+    step_key: str
+    title: str
+    step_type: WorkflowStepType
+    status: WorkflowStepStatus
+    assigned_user_id: UUID | None = None
+    assigned_agent_id: UUID | None = None
+    task_id: UUID | None = None
+    approval_id: UUID | None = None
+    depends_on_step_ids: list[UUID] = Field(default_factory=list)
+    instructions: str | None = None
+    input_json: dict[str, object] | None = None
+    output_json: dict[str, object] | None = None
+    due_at: datetime | None = None
+    sort_order: int
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkflowRunCreate(SQLModel):
+    workflow_definition_id: UUID | None = None
+    source_task_id: UUID | None = None
+    title: str
+    status: WorkflowRunStatus = "pending"
+    current_step_key: str | None = None
+    context_json: dict[str, object] | None = None
+    result_json: dict[str, object] | None = None
+    steps: list[WorkflowStepCreate] = Field(default_factory=list)
+
+
+class WorkflowRunUpdate(SQLModel):
+    status: WorkflowRunStatus | None = None
+    current_step_key: str | None = None
+    context_json: dict[str, object] | None = None
+    result_json: dict[str, object] | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class WorkflowRunRead(SQLModel):
+    id: UUID
+    board_id: UUID
+    workflow_definition_id: UUID | None = None
+    source_task_id: UUID | None = None
+    title: str
+    status: WorkflowRunStatus
+    current_step_key: str | None = None
+    created_by_user_id: UUID | None = None
+    created_by_agent_id: UUID | None = None
+    context_json: dict[str, object] | None = None
+    result_json: dict[str, object] | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+    steps: list[WorkflowStepRead] = Field(default_factory=list)
+
+
+class WorkflowRunSummary(SQLModel):
+    id: UUID
+    title: str
+    status: WorkflowRunStatus
+    current_step_key: str | None = None
+    source_task_id: UUID | None = None
+    waiting_step_count: int = 0
+    approval_step_count: int = 0
+    human_step_count: int = 0
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/board_snapshot.py
+++ b/backend/app/services/board_snapshot.py
@@ -11,10 +11,12 @@ from app.models.agents import Agent
 from app.models.approvals import Approval
 from app.models.board_memory import BoardMemory
 from app.models.tasks import Task
+from app.models.workflows import WorkflowRun, WorkflowStep
 from app.schemas.approvals import ApprovalRead
 from app.schemas.board_memory import BoardMemoryRead
 from app.schemas.boards import BoardRead
 from app.schemas.view_models import BoardSnapshot, TaskCardRead
+from app.schemas.workflows import WorkflowRunSummary
 from app.services.approval_task_links import load_task_ids_by_approval, task_counts_for_board
 from app.services.openclaw.provisioning_db import AgentLifecycleService
 from app.services.tags import TagState, load_tag_state
@@ -73,18 +75,55 @@ def _task_to_card(
     )
     if task.status == "done":
         blocked_by_task_ids = []
-    return card.model_copy(
-        update={
-            "assignee": assignee,
-            "approvals_count": approvals_count,
-            "approvals_pending_count": approvals_pending_count,
-            "depends_on_task_ids": depends_on_task_ids,
-            "tag_ids": tag_state.tag_ids,
-            "tags": tag_state.tags,
-            "blocked_by_task_ids": blocked_by_task_ids,
-            "is_blocked": bool(blocked_by_task_ids),
-        },
+    payload = card.model_dump()
+    payload.pop("assignee", None)
+    payload.pop("approvals_count", None)
+    payload.pop("approvals_pending_count", None)
+    payload.pop("depends_on_task_ids", None)
+    payload.pop("tag_ids", None)
+    payload.pop("tags", None)
+    payload.pop("blocked_by_task_ids", None)
+    payload.pop("is_blocked", None)
+    return TaskCardRead(
+        **payload,
+        assignee=assignee,
+        approvals_count=approvals_count,
+        approvals_pending_count=approvals_pending_count,
+        depends_on_task_ids=depends_on_task_ids,
+        tag_ids=tag_state.tag_ids,
+        tags=tag_state.tags,
+        blocked_by_task_ids=blocked_by_task_ids,
+        is_blocked=bool(blocked_by_task_ids),
     )
+
+
+async def _workflow_run_summaries(session: AsyncSession, *, board_id: UUID) -> list[WorkflowRunSummary]:
+    runs = (
+        await WorkflowRun.objects.filter_by(board_id=board_id)
+        .order_by(col(WorkflowRun.created_at).desc())
+        .limit(50)
+        .all(session)
+    )
+    summaries: list[WorkflowRunSummary] = []
+    for run in runs:
+        steps = await WorkflowStep.objects.filter_by(workflow_run_id=run.id).all(session)
+        summaries.append(
+            WorkflowRunSummary(
+                id=run.id,
+                title=run.title,
+                status=run.status,
+                current_step_key=run.current_step_key,
+                source_task_id=run.source_task_id,
+                waiting_step_count=sum(
+                    1 for step in steps if step.status in {"waiting_human", "waiting_approval"}
+                ),
+                approval_step_count=sum(1 for step in steps if step.step_type == "approval"),
+                human_step_count=sum(1 for step in steps if step.step_type == "human_task"),
+                created_at=run.created_at,
+                updated_at=run.updated_at,
+            )
+        )
+    return summaries
 
 
 async def build_board_snapshot(session: AsyncSession, board: Board) -> BoardSnapshot:
@@ -195,6 +234,7 @@ async def build_board_snapshot(session: AsyncSession, board: Board) -> BoardSnap
     )
     chat_messages.sort(key=lambda item: item.created_at)
     chat_reads = [_memory_to_read(memory) for memory in chat_messages]
+    workflow_runs = await _workflow_run_summaries(session, board_id=board.id)
 
     return BoardSnapshot(
         board=board_read,
@@ -203,4 +243,5 @@ async def build_board_snapshot(session: AsyncSession, board: Board) -> BoardSnap
         approvals=approval_reads,
         chat_messages=chat_reads,
         pending_approvals_count=pending_approvals_count,
+        workflow_runs=workflow_runs,
     )

--- a/backend/migrations/versions/d1f4e7a9b2c3_add_workflow_tables.py
+++ b/backend/migrations/versions/d1f4e7a9b2c3_add_workflow_tables.py
@@ -1,0 +1,171 @@
+"""add workflow tables
+
+Revision ID: d1f4e7a9b2c3
+Revises: a9b1c2d3e4f7
+Create Date: 2026-04-25 16:10:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d1f4e7a9b2c3"
+down_revision = "a9b1c2d3e4f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_definitions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("board_id", sa.Uuid(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("status", sa.String(), nullable=False, server_default="draft"),
+        sa.Column("trigger_mode", sa.String(), nullable=False, server_default="manual"),
+        sa.Column("step_graph_json", sa.JSON(), nullable=True),
+        sa.Column("default_policy_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["board_id"], ["boards.id"]),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_workflow_definitions_board_id"), "workflow_definitions", ["board_id"], unique=False)
+    op.create_index(op.f("ix_workflow_definitions_organization_id"), "workflow_definitions", ["organization_id"], unique=False)
+    op.create_index(op.f("ix_workflow_definitions_slug"), "workflow_definitions", ["slug"], unique=False)
+    op.create_index(op.f("ix_workflow_definitions_status"), "workflow_definitions", ["status"], unique=False)
+
+    op.create_table(
+        "workflow_runs",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("board_id", sa.Uuid(), nullable=False),
+        sa.Column("workflow_definition_id", sa.Uuid(), nullable=True),
+        sa.Column("source_task_id", sa.Uuid(), nullable=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("current_step_key", sa.String(), nullable=True),
+        sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by_agent_id", sa.Uuid(), nullable=True),
+        sa.Column("context_json", sa.JSON(), nullable=True),
+        sa.Column("result_json", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["board_id"], ["boards.id"]),
+        sa.ForeignKeyConstraint(["created_by_agent_id"], ["agents.id"]),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["source_task_id"], ["tasks.id"]),
+        sa.ForeignKeyConstraint(["workflow_definition_id"], ["workflow_definitions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_workflow_runs_board_id"), "workflow_runs", ["board_id"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_created_by_agent_id"), "workflow_runs", ["created_by_agent_id"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_created_by_user_id"), "workflow_runs", ["created_by_user_id"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_current_step_key"), "workflow_runs", ["current_step_key"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_source_task_id"), "workflow_runs", ["source_task_id"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_status"), "workflow_runs", ["status"], unique=False)
+    op.create_index(op.f("ix_workflow_runs_workflow_definition_id"), "workflow_runs", ["workflow_definition_id"], unique=False)
+
+    op.create_table(
+        "workflow_steps",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("workflow_run_id", sa.Uuid(), nullable=False),
+        sa.Column("step_key", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("step_type", sa.String(), nullable=False, server_default="agent_task"),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("assigned_user_id", sa.Uuid(), nullable=True),
+        sa.Column("assigned_agent_id", sa.Uuid(), nullable=True),
+        sa.Column("task_id", sa.Uuid(), nullable=True),
+        sa.Column("approval_id", sa.Uuid(), nullable=True),
+        sa.Column("depends_on_step_ids_json", sa.JSON(), nullable=True),
+        sa.Column("instructions", sa.String(), nullable=True),
+        sa.Column("input_json", sa.JSON(), nullable=True),
+        sa.Column("output_json", sa.JSON(), nullable=True),
+        sa.Column("due_at", sa.DateTime(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["approval_id"], ["approvals.id"]),
+        sa.ForeignKeyConstraint(["assigned_agent_id"], ["agents.id"]),
+        sa.ForeignKeyConstraint(["assigned_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.ForeignKeyConstraint(["workflow_run_id"], ["workflow_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_workflow_steps_approval_id"), "workflow_steps", ["approval_id"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_assigned_agent_id"), "workflow_steps", ["assigned_agent_id"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_assigned_user_id"), "workflow_steps", ["assigned_user_id"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_status"), "workflow_steps", ["status"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_step_key"), "workflow_steps", ["step_key"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_step_type"), "workflow_steps", ["step_type"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_task_id"), "workflow_steps", ["task_id"], unique=False)
+    op.create_index(op.f("ix_workflow_steps_workflow_run_id"), "workflow_steps", ["workflow_run_id"], unique=False)
+
+    op.create_table(
+        "workflow_step_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("workflow_run_id", sa.Uuid(), nullable=False),
+        sa.Column("workflow_step_id", sa.Uuid(), nullable=True),
+        sa.Column("actor_user_id", sa.Uuid(), nullable=True),
+        sa.Column("actor_agent_id", sa.Uuid(), nullable=True),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["actor_agent_id"], ["agents.id"]),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["workflow_run_id"], ["workflow_runs.id"]),
+        sa.ForeignKeyConstraint(["workflow_step_id"], ["workflow_steps.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_workflow_step_events_actor_agent_id"), "workflow_step_events", ["actor_agent_id"], unique=False)
+    op.create_index(op.f("ix_workflow_step_events_actor_user_id"), "workflow_step_events", ["actor_user_id"], unique=False)
+    op.create_index(op.f("ix_workflow_step_events_event_type"), "workflow_step_events", ["event_type"], unique=False)
+    op.create_index(op.f("ix_workflow_step_events_workflow_run_id"), "workflow_step_events", ["workflow_run_id"], unique=False)
+    op.create_index(op.f("ix_workflow_step_events_workflow_step_id"), "workflow_step_events", ["workflow_step_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_workflow_step_events_workflow_step_id"), table_name="workflow_step_events")
+    op.drop_index(op.f("ix_workflow_step_events_workflow_run_id"), table_name="workflow_step_events")
+    op.drop_index(op.f("ix_workflow_step_events_event_type"), table_name="workflow_step_events")
+    op.drop_index(op.f("ix_workflow_step_events_actor_user_id"), table_name="workflow_step_events")
+    op.drop_index(op.f("ix_workflow_step_events_actor_agent_id"), table_name="workflow_step_events")
+    op.drop_table("workflow_step_events")
+
+    op.drop_index(op.f("ix_workflow_steps_workflow_run_id"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_task_id"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_step_type"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_step_key"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_status"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_assigned_user_id"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_assigned_agent_id"), table_name="workflow_steps")
+    op.drop_index(op.f("ix_workflow_steps_approval_id"), table_name="workflow_steps")
+    op.drop_table("workflow_steps")
+
+    op.drop_index(op.f("ix_workflow_runs_workflow_definition_id"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_status"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_source_task_id"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_current_step_key"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_created_by_user_id"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_created_by_agent_id"), table_name="workflow_runs")
+    op.drop_index(op.f("ix_workflow_runs_board_id"), table_name="workflow_runs")
+    op.drop_table("workflow_runs")
+
+    op.drop_index(op.f("ix_workflow_definitions_status"), table_name="workflow_definitions")
+    op.drop_index(op.f("ix_workflow_definitions_slug"), table_name="workflow_definitions")
+    op.drop_index(op.f("ix_workflow_definitions_organization_id"), table_name="workflow_definitions")
+    op.drop_index(op.f("ix_workflow_definitions_board_id"), table_name="workflow_definitions")
+    op.drop_table("workflow_definitions")

--- a/backend/tests/test_workflow_api.py
+++ b/backend/tests/test_workflow_api.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.deps import ActorContext
+from app.api.workflows import create_workflow_run, get_workflow_run, update_workflow_step
+from app.models.agents import Agent
+from app.models.boards import Board
+from app.models.gateways import Gateway
+from app.models.organizations import Organization
+from app.models.tasks import Task
+from app.schemas.workflows import WorkflowRunCreate, WorkflowStepCreate, WorkflowStepUpdate
+
+
+async def _make_engine() -> AsyncEngine:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    return engine
+
+
+async def _seed(session: AsyncSession) -> tuple[Board, Agent, Task]:
+    organization_id = uuid4()
+    gateway = Gateway(
+        id=uuid4(),
+        organization_id=organization_id,
+        name="gateway",
+        url="https://gateway.local",
+        workspace_root="/tmp/workspace",
+    )
+    board = Board(
+        id=uuid4(),
+        organization_id=organization_id,
+        gateway_id=gateway.id,
+        name="board",
+        slug=f"board-{uuid4()}",
+        description="board",
+    )
+    agent = Agent(
+        id=uuid4(),
+        board_id=board.id,
+        gateway_id=gateway.id,
+        name="agent",
+        status="online",
+    )
+    task = Task(id=uuid4(), board_id=board.id, title="task")
+    session.add(Organization(id=organization_id, name=f"org-{organization_id}"))
+    session.add(gateway)
+    session.add(board)
+    session.add(agent)
+    session.add(task)
+    await session.commit()
+    return board, agent, task
+
+
+@pytest.mark.asyncio
+async def test_create_and_update_workflow_run_roundtrip() -> None:
+    engine = await _make_engine()
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            board, agent, task = await _seed(session)
+            actor = ActorContext(actor_type="agent", agent=agent)
+
+            created = await create_workflow_run(
+                payload=WorkflowRunCreate(
+                    title="workflow",
+                    source_task_id=task.id,
+                    status="running",
+                    current_step_key="triage",
+                    steps=[
+                        WorkflowStepCreate(
+                            step_key="triage",
+                            title="Triage",
+                            step_type="agent_task",
+                            status="running",
+                            task_id=task.id,
+                        ),
+                        WorkflowStepCreate(
+                            step_key="review",
+                            title="Review",
+                            step_type="human_task",
+                            status="waiting_human",
+                        ),
+                    ],
+                ),
+                board=board,
+                session=session,
+                actor=actor,
+            )
+
+            assert created.title == "workflow"
+            assert len(created.steps) == 2
+            assert created.steps[1].status == "waiting_human"
+
+            updated_step = await update_workflow_step(
+                step_id=created.steps[1].id,
+                payload=WorkflowStepUpdate(status="completed"),
+                board=board,
+                session=session,
+                actor=actor,
+            )
+            assert updated_step.status == "completed"
+            assert updated_step.completed_at is not None
+
+            fetched = await get_workflow_run(
+                run_id=created.id,
+                board=board,
+                session=session,
+                _actor=actor,
+            )
+            assert fetched.id == created.id
+            assert len(fetched.steps) == 2
+            assert fetched.steps[1].status == "completed"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_workflow_models_and_snapshot.py
+++ b/backend/tests/test_workflow_models_and_snapshot.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.activity_events import ActivityEvent
+from app.models.approvals import Approval
+from app.models.boards import Board
+from app.models.gateways import Gateway
+from app.models.organizations import Organization
+from app.models.tasks import Task
+from app.models.workflows import WorkflowDefinition, WorkflowRun, WorkflowStep
+from app.services.board_snapshot import build_board_snapshot
+
+
+@pytest.mark.asyncio
+async def test_board_snapshot_includes_workflow_run_summaries() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            org_id = uuid4()
+            gateway_id = uuid4()
+            board_id = uuid4()
+            session.add(Organization(id=org_id, name="org"))
+            session.add(
+                Gateway(
+                    id=gateway_id,
+                    organization_id=org_id,
+                    name="gateway",
+                    url="https://gateway.local",
+                    workspace_root="/tmp/workspace",
+                )
+            )
+            board = Board(
+                id=board_id,
+                organization_id=org_id,
+                gateway_id=gateway_id,
+                name="Board",
+                slug="board",
+                description="Workflow board",
+            )
+            task = Task(id=uuid4(), board_id=board_id, title="Task")
+            session.add(board)
+            session.add(task)
+            definition = WorkflowDefinition(
+                organization_id=org_id,
+                board_id=board_id,
+                name="Plan workflow",
+                slug="plan-workflow",
+                status="active",
+            )
+            session.add(definition)
+            await session.flush()
+            run = WorkflowRun(
+                board_id=board_id,
+                workflow_definition_id=definition.id,
+                source_task_id=task.id,
+                title="Plan workflow run",
+                status="waiting_human",
+                current_step_key="review",
+            )
+            session.add(run)
+            await session.flush()
+            session.add(
+                WorkflowStep(
+                    workflow_run_id=run.id,
+                    step_key="review",
+                    title="Human review",
+                    step_type="human_task",
+                    status="waiting_human",
+                    task_id=task.id,
+                    sort_order=0,
+                )
+            )
+            session.add(
+                Approval(
+                    board_id=board_id,
+                    task_id=task.id,
+                    action_type="task.review",
+                    confidence=90,
+                    status="pending",
+                )
+            )
+            session.add(ActivityEvent(event_type="task.created", task_id=task.id, board_id=board_id))
+            await session.commit()
+
+            snapshot = await build_board_snapshot(session, board)
+
+            assert len(snapshot.workflow_runs) == 1
+            summary = snapshot.workflow_runs[0]
+            assert summary.title == "Plan workflow run"
+            assert summary.status == "waiting_human"
+            assert summary.current_step_key == "review"
+            assert summary.human_step_count == 1
+            assert summary.waiting_step_count == 1
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_workflow_schema.py
+++ b/backend/tests/test_workflow_schema.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.schemas.workflows import WorkflowDefinitionCreate, WorkflowRunCreate, WorkflowStepCreate
+
+
+def test_workflow_definition_requires_trimmed_name_and_slug() -> None:
+    created = WorkflowDefinitionCreate(
+        name="  Intake workflow  ",
+        slug=" intake-workflow ",
+        description="  test  ",
+    )
+    assert created.name == "Intake workflow"
+    assert created.slug == "intake-workflow"
+    assert created.description == "test"
+
+
+def test_workflow_run_create_supports_mixed_step_types() -> None:
+    run = WorkflowRunCreate(
+        title="Launch workflow",
+        workflow_definition_id=uuid4(),
+        steps=[
+            WorkflowStepCreate(step_key="triage", title="Triage", step_type="agent_task"),
+            WorkflowStepCreate(step_key="approve", title="Approve", step_type="approval"),
+            WorkflowStepCreate(step_key="human", title="Human step", step_type="human_task"),
+        ],
+    )
+    assert len(run.steps) == 3
+    assert run.steps[1].step_type == "approval"
+    assert run.steps[2].step_type == "human_task"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -124,6 +124,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -585,6 +586,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -608,6 +610,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3450,6 +3453,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3770,8 +3774,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3931,6 +3934,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3941,6 +3945,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4033,6 +4038,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4667,6 +4673,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5388,6 +5395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5954,6 +5962,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -6389,8 +6398,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.2",
@@ -6461,6 +6469,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -6747,6 +6756,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6932,6 +6942,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8946,6 +8957,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8992,6 +9004,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -9430,7 +9443,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10551,6 +10563,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
       "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.7",
         "@swc/helpers": "0.5.15",
@@ -10926,6 +10939,7 @@
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -11442,6 +11456,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11630,7 +11645,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11646,7 +11660,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11659,8 +11672,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -11797,6 +11809,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11806,6 +11819,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11852,6 +11866,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -12011,7 +12026,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -13382,6 +13398,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13698,6 +13715,7 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -13774,6 +13792,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14175,6 +14194,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14268,6 +14288,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14281,6 +14302,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -14689,6 +14711,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/api/generated/model/boardSnapshot.ts
+++ b/frontend/src/api/generated/model/boardSnapshot.ts
@@ -9,6 +9,7 @@ import type { ApprovalRead } from "./approvalRead";
 import type { BoardMemoryRead } from "./boardMemoryRead";
 import type { BoardRead } from "./boardRead";
 import type { TaskCardRead } from "./taskCardRead";
+import type { WorkflowRunSummary } from "./workflowRunSummary";
 
 /**
  * Aggregated board payload used by board snapshot endpoints.
@@ -20,4 +21,5 @@ export interface BoardSnapshot {
   chat_messages: BoardMemoryRead[];
   pending_approvals_count?: number;
   tasks: TaskCardRead[];
+  workflow_runs?: WorkflowRunSummary[];
 }

--- a/frontend/src/api/generated/model/index.ts
+++ b/frontend/src/api/generated/model/index.ts
@@ -233,3 +233,4 @@ export * from "./userRead";
 export * from "./userUpdate";
 export * from "./validationError";
 export * from "./validationErrorCtx";
+export * from "./workflowRunSummary";

--- a/frontend/src/api/generated/model/workflowRunSummary.ts
+++ b/frontend/src/api/generated/model/workflowRunSummary.ts
@@ -1,0 +1,23 @@
+/**
+ * Generated manually to match backend workflow summary payload.
+ */
+export interface WorkflowRunSummary {
+  id: string;
+  title: string;
+  status:
+    | "pending"
+    | "running"
+    | "blocked"
+    | "waiting_human"
+    | "waiting_approval"
+    | "completed"
+    | "failed"
+    | "canceled";
+  current_step_key?: string | null;
+  source_task_id?: string | null;
+  waiting_step_count?: number;
+  approval_step_count?: number;
+  human_step_count?: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/app/boards/[boardId]/page.tsx
+++ b/frontend/src/app/boards/[boardId]/page.tsx
@@ -29,6 +29,7 @@ import { Markdown } from "@/components/atoms/Markdown";
 import { StatusDot } from "@/components/atoms/StatusDot";
 import { DashboardSidebar } from "@/components/organisms/DashboardSidebar";
 import { TaskBoard } from "@/components/organisms/TaskBoard";
+import { WorkflowRunsPanel } from "@/components/boards/WorkflowRunsPanel";
 import {
   DependencyBanner,
   type DependencyBannerDependency,
@@ -105,6 +106,7 @@ import type {
   TaskCustomFieldDefinitionRead,
   TagRead,
   TaskRead,
+  WorkflowRunSummary,
 } from "@/api/generated/model";
 import { createExponentialBackoff } from "@/lib/backoff";
 import {
@@ -886,6 +888,7 @@ export default function BoardDetailPage() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const [approvals, setApprovals] = useState<Approval[]>([]);
+  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRunSummary[]>([]);
   const [isApprovalsLoading, setIsApprovalsLoading] = useState(false);
   const [approvalsError, setApprovalsError] = useState<string | null>(null);
   const [approvalsUpdatingId, setApprovalsUpdatingId] = useState<string | null>(
@@ -1267,6 +1270,7 @@ export default function BoardDetailPage() {
       setAgents((snapshot.agents ?? []).map(normalizeAgent));
       setApprovals((snapshot.approvals ?? []).map(normalizeApproval));
       setChatMessages(snapshot.chat_messages ?? []);
+      setWorkflowRuns(snapshot.workflow_runs ?? []);
 
       try {
         const groupResult =
@@ -3316,6 +3320,8 @@ export default function BoardDetailPage() {
                 <>
                   {viewMode === "list" ? (
                     <>
+                      <WorkflowRunsPanel runs={workflowRuns} />
+
                       {groupSnapshotError ? (
                         <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 shadow-sm">
                           {groupSnapshotError}
@@ -3537,12 +3543,15 @@ export default function BoardDetailPage() {
                   ) : null}
 
                   {viewMode === "board" ? (
-                    <TaskBoard
-                      tasks={tasks}
-                      onTaskSelect={openComments}
-                      onTaskMove={canWrite ? handleTaskMove : undefined}
-                      readOnly={!canWrite}
-                    />
+                    <div className="space-y-6">
+                      <WorkflowRunsPanel runs={workflowRuns} />
+                      <TaskBoard
+                        tasks={tasks}
+                        onTaskSelect={openComments}
+                        onTaskMove={canWrite ? handleTaskMove : undefined}
+                        readOnly={!canWrite}
+                      />
+                    </div>
                   ) : (
                     <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
                       <div className="border-b border-slate-200 px-5 py-4">

--- a/frontend/src/components/boards/WorkflowRunsPanel.test.tsx
+++ b/frontend/src/components/boards/WorkflowRunsPanel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+
+import { WorkflowRunsPanel } from "./WorkflowRunsPanel";
+
+describe("WorkflowRunsPanel", () => {
+  it("renders workflow run summaries", () => {
+    render(
+      <WorkflowRunsPanel
+        runs={[
+          {
+            id: "run-1",
+            title: "Research → plan",
+            status: "waiting_human",
+            current_step_key: "review",
+            source_task_id: "task-1",
+            waiting_step_count: 1,
+            approval_step_count: 0,
+            human_step_count: 1,
+            created_at: "2026-04-25T20:00:00Z",
+            updated_at: "2026-04-25T20:05:00Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Workflow runs")).toBeInTheDocument();
+    expect(screen.getByText("Research → plan")).toBeInTheDocument();
+    expect(screen.getByText(/Current step: review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Waiting 1/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state", () => {
+    render(<WorkflowRunsPanel runs={[]} />);
+
+    expect(screen.getByText(/No workflow runs yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/boards/WorkflowRunsPanel.tsx
+++ b/frontend/src/components/boards/WorkflowRunsPanel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { GitBranch, PauseCircle, PlayCircle, ShieldAlert, UserRound } from "lucide-react";
+
+import type { WorkflowRunSummary } from "@/api/generated/model";
+import { cn } from "@/lib/utils";
+
+const statusTone = (status: WorkflowRunSummary["status"]) => {
+  switch (status) {
+    case "running":
+      return "border-violet-200 bg-violet-50 text-violet-700";
+    case "waiting_human":
+      return "border-amber-200 bg-amber-50 text-amber-700";
+    case "waiting_approval":
+      return "border-cyan-200 bg-cyan-50 text-cyan-700";
+    case "blocked":
+      return "border-rose-200 bg-rose-50 text-rose-700";
+    case "completed":
+      return "border-emerald-200 bg-emerald-50 text-emerald-700";
+    case "failed":
+      return "border-rose-200 bg-rose-50 text-rose-700";
+    case "canceled":
+      return "border-slate-300 bg-slate-100 text-slate-700";
+    default:
+      return "border-slate-200 bg-slate-100 text-slate-700";
+  }
+};
+
+const statusLabel = (status: WorkflowRunSummary["status"]) =>
+  status.replace(/_/g, " ");
+
+type WorkflowRunsPanelProps = {
+  runs: WorkflowRunSummary[];
+};
+
+export function WorkflowRunsPanel({ runs }: WorkflowRunsPanelProps) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-5 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Workflow runs</p>
+            <p className="text-xs text-slate-500">
+              First-class workflow state for this board.
+            </p>
+          </div>
+          <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-700">
+            {runs.length} total
+          </div>
+        </div>
+      </div>
+
+      {runs.length === 0 ? (
+        <div className="px-5 py-8 text-sm text-slate-500">
+          No workflow runs yet.
+        </div>
+      ) : (
+        <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
+          {runs.map((run) => (
+            <article
+              key={run.id}
+              className="rounded-xl border border-slate-200 bg-slate-50/50 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-slate-900">
+                    {run.title}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    Current step: {run.current_step_key ?? "—"}
+                  </p>
+                </div>
+                <span
+                  className={cn(
+                    "rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide",
+                    statusTone(run.status),
+                  )}
+                >
+                  {statusLabel(run.status)}
+                </span>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
+                <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-1">
+                  <PauseCircle className="h-3.5 w-3.5" />
+                  Waiting {run.waiting_step_count ?? 0}
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-1">
+                  <ShieldAlert className="h-3.5 w-3.5" />
+                  Approvals {run.approval_step_count ?? 0}
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-1">
+                  <UserRound className="h-3.5 w-3.5" />
+                  Human {run.human_step_count ?? 0}
+                </span>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between text-xs text-slate-500">
+                <span className="inline-flex items-center gap-1">
+                  <GitBranch className="h-3.5 w-3.5" />
+                  {run.source_task_id ? "Linked to task" : "No task link"}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <PlayCircle className="h-3.5 w-3.5" />
+                  Updated {new Date(run.updated_at).toLocaleDateString()}
+                </span>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
This PR includes the first usable workflow vertical slice.

## Backend
- add workflow definitions, runs, steps, and step events
- add workflow API routes
- add board snapshot workflow summaries
- add migration + tests

## Frontend
- render workflow runs in board UI from snapshot data
- add workflow runs panel + tests

## Verification
- targeted backend tests passed
- targeted frontend tests passed
- frontend production build passed