### PR TITLE
fix(auth): compose first+last name before falling back to first_name alone

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -160,11 +160,12 @@ def _extract_clerk_profile(profile: ClerkUser | None) -> tuple[str | None, str |
         if profile_email is None:
             profile_email = fallback_email
 
+    # Prefer a complete name field, then compose from first+last, then fall
+    # back to username. Composing must come BEFORE falling back to first_name
+    # alone, otherwise users with both first and last names lose the last name.
     profile_name = (
         _non_empty_str(getattr(profile, "full_name", None))
         or _non_empty_str(getattr(profile, "name", None))
-        or _non_empty_str(getattr(profile, "first_name", None))
-        or _non_empty_str(getattr(profile, "username", None))
     )
     if not profile_name:
         first = _non_empty_str(getattr(profile, "first_name", None))
@@ -172,6 +173,8 @@ def _extract_clerk_profile(profile: ClerkUser | None) -> tuple[str | None, str |
         parts = [part for part in (first, last) if part]
         if parts:
             profile_name = " ".join(parts)
+    if not profile_name:
+        profile_name = _non_empty_str(getattr(profile, "username", None))
 
     return profile_email, profile_name
 

--- a/backend/tests/test_auth_claims.py
+++ b/backend/tests/test_auth_claims.py
@@ -77,7 +77,7 @@ def test_extract_clerk_profile_prefers_primary_email() -> None:
     )
     email, name = auth._extract_clerk_profile(profile)
     assert email == "primary@example.com"
-    assert name == "Asha"
+    assert name == "Asha Rao"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes a name-resolution bug in `_extract_clerk_profile` (`backend/app/core/auth.py`).

The previous `or` chain short-circuited to `first_name` whenever it was present, so any Clerk user with both a first and last name (but no `full_name`/`name`) was stored using only their first name. The composed-name branch underneath was effectively unreachable.

## Changes

- Reorder name resolution to: `full_name` → `name` → composed `first_name + last_name` → `username`.
- Update `tests/test_auth_claims.py::test_extract_clerk_profile_prefers_primary_email` to assert the corrected "Asha Rao" (was "Asha").

## Test evidence

Ran the backend suite via `uv run pytest`:

```
318 passed, 1 xfailed in 50.33s
```

No other regressions.

---

Conversation: https://app.warp.dev/conversation/172591c1-c0e9-4f48-9865-8448ed2fb5a1

Co-Authored-By: Oz <oz-agent@warp.dev>