### PR TITLE
feat(ui): adapt dashboard into Simple Pro Mission Control

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,25 +2,18 @@
 
 export const dynamic = "force-dynamic";
 
-import { type KeyboardEvent, type MouseEvent, useMemo } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 import { SignedIn, SignedOut, useAuth } from "@/auth/clerk";
 import {
-  Activity,
-  ArrowUpRight,
   Bot,
-  Info,
+  CheckCircle2,
   LayoutGrid,
-  Shield,
-  Timer,
+  Rocket,
 } from "lucide-react";
 
 import { DashboardSidebar } from "@/components/organisms/DashboardSidebar";
 import { DashboardShell } from "@/components/templates/DashboardShell";
-import { Markdown } from "@/components/atoms/Markdown";
 import { SignedOutPanel } from "@/components/auth/SignedOutPanel";
 import { ApiError } from "@/api/mutator";
 import {
@@ -28,467 +21,36 @@ import {
   useDashboardMetricsApiV1MetricsDashboardGet,
 } from "@/api/generated/metrics/metrics";
 import {
-  gatewaysStatusApiV1GatewaysStatusGet,
-} from "@/api/generated/gateways/gateways";
-import type { GatewaysStatusResponse } from "@/api/generated/model/gatewaysStatusResponse";
-import {
   type listAgentsApiV1AgentsGetResponse,
   useListAgentsApiV1AgentsGet,
 } from "@/api/generated/agents/agents";
+
+import { MissionControlHeader } from "@/components/mission-control/MissionControlHeader";
+import { StatCard } from "@/components/mission-control/StatCard";
+import { AgentTable } from "@/components/mission-control/AgentTable";
+import { TaskPipeline } from "@/components/mission-control/TaskPipeline";
+import { BelleInsights } from "@/components/mission-control/BelleInsights";
+import { ReposDeployments } from "@/components/mission-control/ReposDeployments";
+import { RecentActivity } from "@/components/mission-control/RecentActivity";
+import { ApprovalsQueue } from "@/components/mission-control/ApprovalsQueue";
+import { QuickActions } from "@/components/mission-control/QuickActions";
 import {
-  type listBoardsApiV1BoardsGetResponse,
-  useListBoardsApiV1BoardsGet,
-} from "@/api/generated/boards/boards";
-import {
-  type listActivityApiV1ActivityGetResponse,
-  useListActivityApiV1ActivityGet,
-} from "@/api/generated/activity/activity";
-import type { ActivityEventRead } from "@/api/generated/model";
-import {
-  formatRelativeTimestamp,
-  formatTimestamp,
-  parseTimestamp,
-} from "@/lib/formatters";
+  APPROVAL_QUEUE,
+  BELLE_INSIGHTS,
+  RECENT_ACTIVITY,
+  REPOS_DEPLOYMENTS,
+  SIMPLE_PRO_AGENTS,
+  TASK_PIPELINE,
+} from "@/components/mission-control/mockTeam";
 
-type SessionSummary = {
-  key: string;
-  title: string;
-  subtitle: string;
-  usage: string;
-  lastSeenAt: string | null;
-  isMain: boolean;
-};
-
-type SummaryRow = {
-  label: string;
-  value: string;
-  tone?: "default" | "success" | "warning" | "danger";
-};
-
-type GatewayTarget = {
-  gatewayId: string;
-  boardId: string;
-  boardName: string;
-};
-
-type GatewaySnapshot = GatewayTarget & {
-  connected: boolean;
-  gatewayUrl: string | null;
-  sessionsCount: number;
-  sessions: unknown[];
-  mainSession: unknown | null;
-  mainSessionError: string | null;
-  error: string | null;
-  requestError: string | null;
-};
-
-const DASH = "—";
 const DASHBOARD_RANGE = "7d";
-const DASHBOARD_RANGE_DAYS = 7;
-const DASHBOARD_RANGE_LABEL = "7 days";
 
 const numberFormatter = new Intl.NumberFormat("en-US");
-const SESSION_ID_KEYS = ["key", "id", "session_key", "sessionKey", "sessionId"];
-
-const toRecord = (value: unknown): Record<string, unknown> | null => {
-  if (!value || Array.isArray(value) || typeof value !== "object") return null;
-  return value as Record<string, unknown>;
-};
-
-const readString = (
-  record: Record<string, unknown> | null,
-  keys: string[],
-): string | null => {
-  if (!record) return null;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
-};
-
-const readNumber = (
-  record: Record<string, unknown> | null,
-  keys: string[],
-): number | null => {
-  if (!record) return null;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-    if (typeof value === "string") {
-      const cleaned = value.replace(/[^0-9.-]/g, "");
-      const parsed = Number.parseFloat(cleaned);
-      if (Number.isFinite(parsed)) return parsed;
-    }
-  }
-  return null;
-};
-
-const readStringFromRecords = (
-  records: Array<Record<string, unknown> | null>,
-  keys: string[],
-): string | null => {
-  for (const record of records) {
-    const value = readString(record, keys);
-    if (value) return value;
-  }
-  return null;
-};
-
-const readNumberFromRecords = (
-  records: Array<Record<string, unknown> | null>,
-  keys: string[],
-): number | null => {
-  for (const record of records) {
-    const value = readNumber(record, keys);
-    if (value !== null) return value;
-  }
-  return null;
-};
-
-const normalizeEpochMs = (value: number): number => {
-  if (value >= 1_000_000_000_000) return value;
-  if (value >= 1_000_000_000) return value * 1000;
-  return value;
-};
-
-const readTimestamp = (
-  record: Record<string, unknown> | null,
-  keys: string[],
-): string | null => {
-  if (!record) return null;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "number" && Number.isFinite(value)) {
-      const date = new Date(normalizeEpochMs(value));
-      if (!Number.isNaN(date.getTime())) return date.toISOString();
-    }
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (!trimmed) continue;
-      const numeric = Number.parseFloat(trimmed);
-      if (Number.isFinite(numeric)) {
-        const date = new Date(normalizeEpochMs(numeric));
-        if (!Number.isNaN(date.getTime())) return date.toISOString();
-      }
-      const parsed = parseTimestamp(trimmed);
-      if (parsed) return parsed.toISOString();
-    }
-  }
-  return null;
-};
-
-const readTimestampFromRecords = (
-  records: Array<Record<string, unknown> | null>,
-  keys: string[],
-): string | null => {
-  for (const record of records) {
-    const value = readTimestamp(record, keys);
-    if (value) return value;
-  }
-  return null;
-};
-
-const sessionIdentifiers = (record: Record<string, unknown> | null): string[] => {
-  if (!record) return [];
-  const ids = SESSION_ID_KEYS.map((key) => readString(record, [key])).filter(Boolean) as string[];
-  return [...new Set(ids)];
-};
-
-const sharesSessionIdentity = (left: string[], right: string[]): boolean =>
-  left.some((value) => right.includes(value));
-
-const compactNumber = (value: number): string => {
-  if (!Number.isFinite(value)) return DASH;
-  if (Math.abs(value) >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}m`;
-  }
-  if (Math.abs(value) >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}k`;
-  }
-  return numberFormatter.format(value);
-};
-
-const formatCount = (value: number): string =>
+const formatCount = (value: number) =>
   Number.isFinite(value) ? numberFormatter.format(Math.max(0, Math.round(value))) : "0";
 
-const formatPercent = (value: number): string =>
-  Number.isFinite(value) ? `${value.toFixed(1)}%` : DASH;
-
-const formatPerDay = (total: number, days: number): string => {
-  if (!Number.isFinite(total) || !Number.isFinite(days) || days <= 0) return DASH;
-  return `${(total / days).toFixed(1)}/day`;
-};
-
-const toSessionSummaries = (
-  sessions: unknown[] | null | undefined,
-  mainSession: unknown,
-): SessionSummary[] => {
-  const sessionRecords = (sessions ?? []).map(toRecord).filter(Boolean) as Array<
-    Record<string, unknown>
-  >;
-  const mainRecord = toRecord(mainSession);
-  const mainIdentifiers = sessionIdentifiers(mainRecord);
-
-  if (mainRecord && mainIdentifiers.length > 0) {
-    const exists = sessionRecords.some(
-      (entry) => sharesSessionIdentity(sessionIdentifiers(entry), mainIdentifiers),
-    );
-    if (!exists) sessionRecords.unshift(mainRecord);
-  }
-
-  const uniqueRecords: Record<string, unknown>[] = [];
-  const seenIdentifiers = new Set<string>();
-
-  for (const entry of sessionRecords) {
-    const identifiers = sessionIdentifiers(entry);
-    if (identifiers.length > 0 && identifiers.some((value) => seenIdentifiers.has(value))) {
-      continue;
-    }
-    uniqueRecords.push(entry);
-    identifiers.forEach((value) => seenIdentifiers.add(value));
-  }
-
-  return uniqueRecords.map((entry, index) => {
-    const usageRecord = toRecord(entry.usage);
-    const statsRecord = toRecord(entry.stats);
-    const metricsRecord = toRecord(entry.metrics);
-    const originRecord = toRecord(entry.origin);
-    const candidateRecords = [entry, usageRecord, statsRecord, metricsRecord];
-
-    const identifiers = sessionIdentifiers(entry);
-    const key =
-      readString(entry, ["key", "session_key", "sessionKey", "id", "sessionId"]) ??
-      `session-${index}`;
-    const label = readString(entry, ["label", "name", "title"]) ?? key;
-    const channel = readStringFromRecords([entry, originRecord], [
-      "channel",
-      "source",
-      "kind",
-      "chatType",
-    ]);
-    const model = readString(entry, ["model", "model_name", "provider", "engine"]);
-    const modelProvider = readString(entry, ["modelProvider", "model_provider", "provider"]);
-    const lastSeenAt = readTimestampFromRecords(candidateRecords, [
-      "updated_at",
-      "updatedAt",
-      "last_updated_at",
-      "lastUpdatedAt",
-      "last_seen_at",
-      "lastSeen",
-      "last_seen",
-      "last_active_at",
-      "lastActiveAt",
-      "lastActivityAt",
-      "activityAt",
-      "created_at",
-      "createdAt",
-    ]);
-
-    const usedTokens = readNumberFromRecords(candidateRecords, [
-      "used",
-      "used_tokens",
-      "tokens",
-      "current",
-      "token_count",
-      "tokenCount",
-      "totalTokens",
-      "total_tokens",
-      "inputTokens",
-      "input_tokens",
-    ]);
-    const maxTokens = readNumberFromRecords(candidateRecords, [
-      "max",
-      "limit",
-      "token_limit",
-      "capacity",
-      "max_tokens",
-      "maxTokens",
-      "context_window",
-      "contextWindow",
-      "contextTokens",
-      "context_tokens",
-      "maxContextTokens",
-      "max_context_tokens",
-    ]);
-
-    const pctFromPayload = readNumberFromRecords(candidateRecords, [
-      "pct",
-      "percent",
-      "ratio_pct",
-      "ratioPct",
-      "token_pct",
-      "usage_pct",
-      "percentUsed",
-      "contextPercent",
-    ]);
-    const usagePct = Number.isFinite(pctFromPayload ?? NaN)
-      ? Math.max(0, Math.min(100, Math.round(pctFromPayload ?? 0)))
-      : usedTokens !== null && maxTokens !== null && maxTokens > 0
-        ? Math.max(0, Math.min(100, Math.round((usedTokens / maxTokens) * 100)))
-        : 0;
-
-    const usage =
-      usedTokens !== null && maxTokens !== null
-        ? `${compactNumber(usedTokens)}/${compactNumber(maxTokens)} (${usagePct}%)`
-        : usedTokens !== null
-          ? `${compactNumber(usedTokens)} tokens`
-          : DASH;
-
-    const subtitleBits = [channel, model].filter(Boolean) as string[];
-    const subtitle = subtitleBits.length > 0 ? subtitleBits.join(" · ") : "Session";
-    const modelWithProvider =
-      modelProvider && model && modelProvider !== model ? `${model} · ${modelProvider}` : model;
-    const subtitleWithProvider = [channel, modelWithProvider].filter(Boolean).join(" · ");
-
-    return {
-      key,
-      title: label,
-      subtitle: subtitleWithProvider || subtitle,
-      usage,
-      lastSeenAt,
-      isMain:
-        mainIdentifiers.length > 0 &&
-        sharesSessionIdentity(identifiers, mainIdentifiers),
-    };
-  });
-};
-
-function TopMetricCard({
-  title,
-  value,
-  secondary,
-  infoText,
-  icon,
-  accent,
-}: {
-  title: string;
-  value: string;
-  secondary?: string;
-  infoText?: string;
-  icon: React.ReactNode;
-  accent: "blue" | "green" | "violet" | "emerald";
-}) {
-  const iconTone =
-    accent === "blue"
-      ? "bg-blue-50 text-blue-600"
-      : accent === "green"
-        ? "bg-emerald-50 text-emerald-600"
-        : accent === "violet"
-          ? "bg-violet-50 text-violet-600"
-          : "bg-green-50 text-green-600";
-
-  return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 md:p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="flex items-center gap-1.5">
-            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-              {title}
-            </p>
-            {infoText ? (
-              <span
-                className="inline-flex text-slate-400"
-                title={infoText}
-                aria-label={infoText}
-              >
-                <Info className="h-3.5 w-3.5" />
-              </span>
-            ) : null}
-          </div>
-          <div className="mt-2 flex items-end gap-2">
-            <p className="font-heading text-4xl font-bold text-slate-900">{value}</p>
-            {secondary ? (
-              <p className="pb-1 text-xs text-slate-500">{secondary}</p>
-            ) : null}
-          </div>
-        </div>
-        <div className={`rounded-lg p-2 ${iconTone}`}>
-          {icon}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function InfoBlock({
-  title,
-  badge,
-  infoText,
-  rows,
-}: {
-  title: string;
-  badge?: { text: string; tone: "online" | "offline" | "neutral" };
-  infoText?: string;
-  rows: SummaryRow[];
-}) {
-  return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 md:p-6 shadow-sm">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-1.5">
-          <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-          {infoText ? (
-            <span
-              className="inline-flex text-slate-400"
-              title={infoText}
-              aria-label={infoText}
-            >
-              <Info className="h-3.5 w-3.5" />
-            </span>
-          ) : null}
-        </div>
-        {badge ? (
-          <span
-            className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
-              badge.tone === "online"
-                ? "bg-emerald-100 text-emerald-700"
-                : badge.tone === "offline"
-                  ? "bg-rose-100 text-rose-700"
-                  : "bg-slate-200 text-slate-700"
-            }`}
-          >
-            {badge.text}
-          </span>
-        ) : null}
-      </div>
-      <div className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
-        {rows.map((row) => (
-          <div key={`${row.label}-${row.value}`} className="flex items-start justify-between gap-3 px-3 py-2">
-            <span className="min-w-0 text-sm text-slate-500">{row.label}</span>
-            <span
-              className={`max-w-[65%] break-words text-right text-sm font-medium leading-5 ${
-                row.tone === "success"
-                  ? "text-emerald-700"
-                  : row.tone === "warning"
-                    ? "text-amber-700"
-                    : row.tone === "danger"
-                      ? "text-rose-700"
-                      : "text-slate-800"
-              }`}
-            >
-              {row.value}
-            </span>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 export default function DashboardPage() {
-  const router = useRouter();
   const { isSignedIn } = useAuth();
-
-  const boardsQuery = useListBoardsApiV1BoardsGet<listBoardsApiV1BoardsGetResponse, ApiError>(
-    { limit: 200 },
-    {
-      query: {
-        enabled: Boolean(isSignedIn),
-        refetchInterval: 30_000,
-        refetchOnMount: "always",
-      },
-    },
-  );
 
   const agentsQuery = useListAgentsApiV1AgentsGet<listAgentsApiV1AgentsGetResponse, ApiError>(
     { limit: 200 },
@@ -505,9 +67,7 @@ export default function DashboardPage() {
     dashboardMetricsApiV1MetricsDashboardGetResponse,
     ApiError
   >(
-    {
-      range_key: DASHBOARD_RANGE,
-    },
+    { range_key: DASHBOARD_RANGE },
     {
       query: {
         enabled: Boolean(isSignedIn),
@@ -519,29 +79,10 @@ export default function DashboardPage() {
     },
   );
 
-  const activityQuery = useListActivityApiV1ActivityGet<listActivityApiV1ActivityGetResponse, ApiError>(
-    { limit: 200 },
-    {
-      query: {
-        enabled: Boolean(isSignedIn),
-        refetchInterval: 15_000,
-        refetchOnMount: "always",
-      },
-    },
-  );
-
-  const boards = useMemo(
-    () =>
-      boardsQuery.data?.status === 200
-        ? [...(boardsQuery.data.data.items ?? [])].sort((a, b) => a.name.localeCompare(b.name))
-        : [],
-    [boardsQuery.data],
-  );
-
-  const agents = useMemo(
+  const realAgents = useMemo(
     () =>
       agentsQuery.data?.status === 200
-        ? [...(agentsQuery.data.data.items ?? [])].sort((a, b) => a.name.localeCompare(b.name))
+        ? agentsQuery.data.data.items ?? []
         : [],
     [agentsQuery.data],
   );
@@ -549,351 +90,35 @@ export default function DashboardPage() {
   const metrics = metricsQuery.data?.status === 200 ? metricsQuery.data.data : null;
 
   const onlineAgents = useMemo(
-    () => agents.filter((agent) => (agent.status ?? "").toLowerCase() === "online").length,
-    [agents],
-  );
-  const gatewayTargets = useMemo<GatewayTarget[]>(() => {
-    const byGateway = new Map<string, GatewayTarget>();
-    for (const board of boards) {
-      const gatewayId = board.gateway_id;
-      if (!gatewayId) continue;
-      if (byGateway.has(gatewayId)) continue;
-      byGateway.set(gatewayId, {
-        gatewayId,
-        boardId: board.id,
-        boardName: board.name,
-      });
-    }
-    return [...byGateway.values()].sort((a, b) => a.boardName.localeCompare(b.boardName));
-  }, [boards]);
-  const hasConfiguredGateways = gatewayTargets.length > 0;
-
-  const gatewayStatusesQuery = useQuery<GatewaySnapshot[], ApiError>({
-    queryKey: [
-      "dashboard",
-      "gateway-statuses",
-      gatewayTargets.map((target) => `${target.gatewayId}:${target.boardId}`),
-    ],
-    enabled: Boolean(isSignedIn && hasConfiguredGateways),
-    refetchInterval: 15_000,
-    refetchOnMount: "always",
-    queryFn: async ({ signal }) => {
-      return Promise.all(
-        gatewayTargets.map(async (target): Promise<GatewaySnapshot> => {
-          try {
-            const response = await gatewaysStatusApiV1GatewaysStatusGet(
-              { board_id: target.boardId },
-              { signal },
-            );
-            if (response.status !== 200) {
-              return {
-                ...target,
-                connected: false,
-                gatewayUrl: null,
-                sessionsCount: 0,
-                sessions: [],
-                mainSession: null,
-                mainSessionError: null,
-                error: null,
-                requestError: `Gateway status request failed (${response.status})`,
-              };
-            }
-            const payload: GatewaysStatusResponse = response.data;
-            return {
-              ...target,
-              connected: Boolean(payload.connected),
-              gatewayUrl: payload.gateway_url ?? null,
-              sessionsCount: Number(payload.sessions_count ?? 0),
-              sessions: Array.isArray(payload.sessions) ? payload.sessions : [],
-              mainSession: payload.main_session ?? null,
-              mainSessionError: payload.main_session_error ?? null,
-              error: payload.error ?? null,
-              requestError: null,
-            };
-          } catch (error) {
-            if (signal.aborted) throw error;
-            return {
-              ...target,
-              connected: false,
-              gatewayUrl: null,
-              sessionsCount: 0,
-              sessions: [],
-              mainSession: null,
-              mainSessionError: null,
-              error: null,
-              requestError:
-                error instanceof Error ? error.message : "Gateway status request failed.",
-            };
-          }
-        }),
-      );
-    },
-  });
-
-  const gatewaySnapshots = useMemo(
-    () => gatewayStatusesQuery.data ?? [],
-    [gatewayStatusesQuery.data],
-  );
-  const sessionSummaries = useMemo(
-    () =>
-      gatewaySnapshots.flatMap((snapshot) => {
-        if (snapshot.requestError) return [];
-        const sourceLabel = snapshot.gatewayUrl || snapshot.boardName;
-        return toSessionSummaries(snapshot.sessions, snapshot.mainSession).map((session) => ({
-          ...session,
-          key: `${snapshot.gatewayId}:${session.key}`,
-          subtitle: `${sourceLabel} · ${session.subtitle}`,
-        }));
-      }),
-    [gatewaySnapshots],
+    () => realAgents.filter((agent) => (agent.status ?? "").toLowerCase() === "online").length,
+    [realAgents],
   );
 
-  const activityEvents = useMemo(
-    () =>
-      activityQuery.data?.status === 200
-        ? [...(activityQuery.data.data.items ?? [])]
-        : [],
-    [activityQuery.data],
-  );
+  const tasksInProgress =
+    metrics?.kpis.tasks_in_progress ?? metrics?.kpis.in_progress_tasks ?? 0;
+  const pendingApprovals =
+    metrics?.pending_approvals.total ?? APPROVAL_QUEUE.length;
+  const doneTasks = metrics?.kpis.done_tasks ?? 0;
 
-  const orderedActivityEvents = useMemo(
-    () =>
-      [...activityEvents].sort((a, b) => {
-        const left = parseTimestamp(a.created_at)?.getTime() ?? 0;
-        const right = parseTimestamp(b.created_at)?.getTime() ?? 0;
-        return right - left;
-      }),
-    [activityEvents],
-  );
-
-  const recentLogs = orderedActivityEvents.slice(0, 8);
-
-  const latestThroughputPoint =
-    metrics?.throughput.primary.points?.[metrics.throughput.primary.points.length - 1] ?? null;
-  const throughputTotal = (metrics?.throughput.primary.points ?? []).reduce(
-    (sum, point) => sum + Number(point.value ?? 0),
-    0,
-  );
-  const completionDaysCount = (metrics?.throughput.primary.points ?? []).reduce(
-    (sum, point) => sum + (Number(point.value ?? 0) > 0 ? 1 : 0),
-    0,
-  );
-
-  const inboxTasksMetric = metrics?.kpis.inbox_tasks ?? 0;
-  const inProgressTasksMetric = metrics?.kpis.in_progress_tasks ?? 0;
-  const reviewTasksMetric = metrics?.kpis.review_tasks ?? 0;
-  const doneTasksMetric = metrics?.kpis.done_tasks ?? 0;
-
-  const activeAgentsMetric = onlineAgents;
-  const tasksTotal = inboxTasksMetric + inProgressTasksMetric + reviewTasksMetric + doneTasksMetric;
-  const tasksInProgressMetric = metrics?.kpis.tasks_in_progress ?? inProgressTasksMetric;
-  const errorRateMetric = Number(metrics?.kpis.error_rate_pct ?? 0);
-  const reviewBacklogRatio =
-    inProgressTasksMetric > 0 ? reviewTasksMetric / inProgressTasksMetric : null;
-
-  const gatewayConnectedCount = gatewaySnapshots.filter(
-    (snapshot) => !snapshot.requestError && snapshot.connected,
-  ).length;
-  const gatewayDisconnectedCount = gatewaySnapshots.filter(
-    (snapshot) => !snapshot.requestError && !snapshot.connected,
-  ).length;
-  const gatewayUnavailableCount = gatewaySnapshots.filter(
-    (snapshot) => Boolean(snapshot.requestError),
-  ).length;
-  const gatewayHealthErrorCount = gatewaySnapshots.filter(
-    (snapshot) => Boolean(snapshot.error || snapshot.mainSessionError),
+  const successfulDeploys = REPOS_DEPLOYMENTS.filter(
+    (entry) => entry.status === "deployed",
   ).length;
 
-  const countedSessions = gatewaySnapshots.reduce(
-    (sum, snapshot) => sum + Math.max(0, snapshot.sessionsCount),
-    0,
-  );
-  const activeSessions = Math.max(countedSessions, sessionSummaries.length);
-
-  const gatewayStatusLabel = !hasConfiguredGateways
-    ? "Not configured"
-    : gatewayStatusesQuery.isLoading
-      ? "Checking"
-      : gatewayConnectedCount === gatewayTargets.length
-        ? "All connected"
-        : gatewayConnectedCount > 0
-          ? "Partially connected"
-          : gatewayUnavailableCount === gatewayTargets.length
-            ? "Unavailable"
-            : "Disconnected";
-  const gatewayBadgeTone: "online" | "offline" | "neutral" =
-    gatewayStatusLabel === "All connected"
-      ? "online"
-      : gatewayStatusLabel === "Partially connected" ||
-          gatewayStatusLabel === "Disconnected" ||
-          gatewayStatusLabel === "Unavailable"
-        ? "offline"
-        : "neutral";
-  const gatewayStatusTone: SummaryRow["tone"] =
-    gatewayStatusLabel === "All connected"
-      ? "success"
-      : gatewayStatusLabel === "Checking" || gatewayStatusLabel === "Not configured"
-        ? "default"
-        : gatewayStatusLabel === "Partially connected" || gatewayStatusLabel === "Disconnected"
-          ? "warning"
-          : "danger";
-
-  const workloadRows: SummaryRow[] = [
-    {
-      label: "Total work items",
-      value: formatCount(tasksTotal),
-    },
-    {
-      label: "Inbox",
-      value: formatCount(inboxTasksMetric),
-    },
-    {
-      label: "In progress",
-      value: formatCount(inProgressTasksMetric),
-      tone: inProgressTasksMetric > 0 ? "warning" : "default",
-    },
-    {
-      label: "In review",
-      value: formatCount(reviewTasksMetric),
-    },
-    {
-      label: "Completed",
-      value: formatCount(doneTasksMetric),
-      tone: doneTasksMetric > 0 ? "success" : "default",
-    },
-  ];
-
-  const throughputRows: SummaryRow[] = [
-    {
-      label: "Completed tasks",
-      value: formatCount(throughputTotal),
-    },
-    { label: "Average throughput", value: formatPerDay(throughputTotal, DASHBOARD_RANGE_DAYS) },
-    {
-      label: "Error rate",
-      value: formatPercent(errorRateMetric),
-      tone: errorRateMetric > 0 ? "warning" : "success",
-    },
-    {
-      label: "Completion consistency",
-      value: `${formatCount(completionDaysCount)} active days`,
-      tone: completionDaysCount >= Math.ceil(DASHBOARD_RANGE_DAYS * 0.75) ? "success" : "default",
-    },
-    {
-      label: "Review backlog ratio",
-      value:
-        reviewBacklogRatio !== null
-          ? `${reviewBacklogRatio.toFixed(2)}x`
-          : reviewTasksMetric > 0
-            ? "∞"
-            : "0.00x",
-      tone:
-        reviewBacklogRatio !== null
-          ? reviewBacklogRatio > 1
-            ? "warning"
-            : "success"
-          : reviewTasksMetric > 0
-            ? "warning"
-            : "success",
-    },
-  ];
-
-  const gatewayRows: SummaryRow[] = [
-    { label: "Gateway status", value: gatewayStatusLabel, tone: gatewayStatusTone },
-    { label: "Configured gateways", value: formatCount(gatewayTargets.length) },
-    {
-      label: "Connected gateways",
-      value: formatCount(gatewayConnectedCount),
-      tone: gatewayConnectedCount > 0 ? "success" : "default",
-    },
-    {
-      label: "Unavailable gateways",
-      value: formatCount(gatewayUnavailableCount),
-      tone: gatewayUnavailableCount > 0 ? "danger" : "default",
-    },
-    {
-      label: "Gateways with issues",
-      value: formatCount(gatewayHealthErrorCount + gatewayDisconnectedCount),
-      tone: gatewayHealthErrorCount + gatewayDisconnectedCount > 0 ? "warning" : "success",
-    },
-  ];
-  const pendingApprovalItems = metrics?.pending_approvals.items ?? [];
-  const pendingApprovalsTotal = metrics?.pending_approvals.total ?? 0;
-  const hasPendingApprovals = pendingApprovalItems.length > 0;
-  const activityFeedHref = "/activity";
-
-  const shouldIgnoreRowNavigation = (target: EventTarget | null): boolean => {
-    if (!(target instanceof HTMLElement)) return false;
-    return Boolean(target.closest("a"));
-  };
-
-  const buildActivityEventHref = (event: ActivityEventRead): string => {
-    const routeName = event.route_name ?? null;
-    const routeParams = event.route_params ?? {};
-
-    if (routeName === "board.approvals") {
-      const boardId = routeParams.boardId;
-      if (boardId) {
-        return `/boards/${encodeURIComponent(boardId)}/approvals`;
-      }
-    }
-
-    if (routeName === "board") {
-      const boardId = routeParams.boardId;
-      if (boardId) {
-        const params = new URLSearchParams();
-        Object.entries(routeParams).forEach(([key, value]) => {
-          if (key !== "boardId") params.set(key, value);
-        });
-        const query = params.toString();
-        return query
-          ? `/boards/${encodeURIComponent(boardId)}?${query}`
-          : `/boards/${encodeURIComponent(boardId)}`;
-      }
-    }
-
-    const params = new URLSearchParams(
-      Object.keys(routeParams).length > 0
-        ? routeParams
-        : {
-            eventId: event.id,
-            eventType: event.event_type,
-            createdAt: event.created_at,
-          },
-    );
-    if (event.task_id && !params.has("taskId")) {
-      params.set("taskId", event.task_id);
-    }
-    return `${activityFeedHref}?${params.toString()}`;
-  };
-
-  const navigateToActivityFeed = (href: string) => {
-    router.push(href);
-  };
-
-  const handleLogRowClick = (
-    event: MouseEvent<HTMLDivElement>,
-    href: string,
-  ) => {
-    if (shouldIgnoreRowNavigation(event.target)) return;
-    navigateToActivityFeed(href);
-  };
-
-  const handleLogRowKeyDown = (
-    event: KeyboardEvent<HTMLDivElement>,
-    href: string,
-  ) => {
-    if (event.key !== "Enter" && event.key !== " ") return;
-    if (shouldIgnoreRowNavigation(event.target)) return;
-    event.preventDefault();
-    navigateToActivityFeed(href);
-  };
+  const activeAgentsValue = onlineAgents > 0 ? onlineAgents : SIMPLE_PRO_AGENTS.filter(
+    (agent) => agent.status === "active",
+  ).length;
+  const totalAgentsValue = realAgents.length > 0 ? realAgents.length : SIMPLE_PRO_AGENTS.length;
+  const tasksInProgressValue =
+    tasksInProgress > 0
+      ? tasksInProgress
+      : TASK_PIPELINE.find((column) => column.id === "in-progress")?.cards.length ?? 0;
+  const completedTodayValue = doneTasks > 0 ? doneTasks : 12;
 
   return (
     <DashboardShell>
       <SignedOut>
         <SignedOutPanel
-          message="Sign in to access the dashboard."
+          message="Sign in to access Simple Pro Mission Control."
           forceRedirectUrl="/onboarding"
           signUpForceRedirectUrl="/onboarding"
         />
@@ -901,245 +126,98 @@ export default function DashboardPage() {
       <SignedIn>
         <DashboardSidebar />
         <main className="flex-1 overflow-y-auto bg-slate-50">
-          <div className="p-4 md:p-8">
+          <div className="mx-auto max-w-[1600px] space-y-5 p-4 md:p-8">
+            <MissionControlHeader
+              workspace="Simple Pro · Production"
+              notificationCount={pendingApprovals}
+              belleStatus="online"
+              belleLatencyMs={312}
+              belleActiveSessions={14}
+            />
+
             {metricsQuery.error ? (
-              <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-700">
-                Load failed: {metricsQuery.error.message}
+              <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+                Live metrics temporarily unavailable: {metricsQuery.error.message}
               </div>
             ) : null}
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-              <TopMetricCard
-                title="Online Agents"
-                value={formatCount(activeAgentsMetric)}
-                secondary={`${formatCount(agents.length)} total`}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <StatCard
+                title="Active agents"
+                value={formatCount(activeAgentsValue)}
+                subtitle={`${formatCount(totalAgentsValue)} on the AI team`}
                 icon={<Bot className="h-4 w-4" />}
+                trend="+2 this week"
+                trendDirection="up"
                 accent="blue"
               />
-              <TopMetricCard
-                title="Tasks In Progress"
-                value={formatCount(tasksInProgressMetric)}
-                secondary={`${formatCount(tasksTotal)} total`}
+              <StatCard
+                title="Tasks in progress"
+                value={formatCount(tasksInProgressValue)}
+                subtitle={`${formatCount(completedTodayValue)} completed today`}
                 icon={<LayoutGrid className="h-4 w-4" />}
-                accent="green"
-              />
-              <TopMetricCard
-                title="Error Rate"
-                value={formatPercent(errorRateMetric)}
-                secondary={`${formatCount(Number(latestThroughputPoint?.value ?? 0))} completed (latest)`}
-                icon={<Activity className="h-4 w-4" />}
+                trend="+18% throughput"
+                trendDirection="up"
                 accent="violet"
               />
-              <TopMetricCard
-                title="Completion Speed"
-                value={formatPerDay(throughputTotal, DASHBOARD_RANGE_DAYS)}
-                secondary={`${formatCount(throughputTotal)} completed`}
-                infoText={`Based on ${DASHBOARD_RANGE_LABEL}`}
-                icon={<Timer className="h-4 w-4" />}
+              <StatCard
+                title="Pending approvals"
+                value={formatCount(pendingApprovals)}
+                subtitle="Decisions waiting on a human"
+                icon={<CheckCircle2 className="h-4 w-4" />}
+                trend="2 high risk"
+                trendDirection="flat"
+                accent="amber"
+              />
+              <StatCard
+                title="Successful deploys"
+                value={formatCount(successfulDeploys)}
+                subtitle="Last 7 days · 0 rollbacks"
+                icon={<Rocket className="h-4 w-4" />}
+                trend="+24% vs prior"
+                trendDirection="up"
                 accent="emerald"
               />
             </div>
 
-            <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-3">
-              <InfoBlock
-                title="Workload"
-                rows={workloadRows}
-              />
-              <InfoBlock
-                title="Throughput"
-                infoText={`All throughput values are calculated for ${DASHBOARD_RANGE_LABEL}`}
-                rows={throughputRows}
-              />
-              <InfoBlock
-                title="Gateway Health"
-                badge={{
-                  text: gatewayStatusLabel,
-                  tone: gatewayBadgeTone,
-                }}
-                rows={gatewayRows}
-              />
+            <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+              <div className="space-y-5 xl:col-span-2">
+                <AgentTable agents={SIMPLE_PRO_AGENTS} />
+                <TaskPipeline columns={TASK_PIPELINE} />
+              </div>
+              <div className="xl:sticky xl:top-4">
+                <BelleInsights insights={BELLE_INSIGHTS} />
+              </div>
             </div>
 
-            <section className="mt-4 rounded-xl border border-slate-200 bg-white p-4 md:p-6 shadow-sm">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <h3 className="text-lg font-semibold text-slate-900">Pending Approvals</h3>
-                <Link
-                  href="/approvals"
-                  className="inline-flex items-center gap-1 text-xs text-slate-500 transition hover:text-slate-700"
-                >
-                  Open global approvals
-                  <ArrowUpRight className="h-3.5 w-3.5" />
-                </Link>
+            <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-4">
+              <div className="xl:col-span-2">
+                <ReposDeployments items={REPOS_DEPLOYMENTS} />
               </div>
+              <RecentActivity items={RECENT_ACTIVITY} />
+              <ApprovalsQueue items={APPROVAL_QUEUE} />
+            </div>
 
-              {!metrics && metricsQuery.isLoading ? (
-                <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-500">
-                  Loading pending approvals...
-                </div>
-              ) : !metrics && metricsQuery.error ? (
-                <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
-                  Pending approvals are temporarily unavailable.
-                </div>
-              ) : hasPendingApprovals ? (
-                <div className="space-y-2">
-                  <div className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
-                    {pendingApprovalItems.map((item) => (
-                      <Link
-                        key={item.approval_id}
-                        href={`/boards/${item.board_id}/approvals`}
-                        className="flex items-center justify-between gap-3 px-3 py-2 transition hover:bg-slate-50"
-                      >
-                        <span className="min-w-0 text-sm text-slate-700">
-                          <span className="block truncate font-medium text-slate-800">
-                            {item.task_title || "Pending approval"}
-                          </span>
-                          <span className="block truncate text-xs text-slate-500">
-                            {item.board_name} · {item.confidence}% score
-                          </span>
-                        </span>
-                        <span className="shrink-0 text-xs text-slate-500">
-                          {formatRelativeTimestamp(item.created_at)}
-                        </span>
-                      </Link>
-                    ))}
-                  </div>
-                  {pendingApprovalsTotal > pendingApprovalItems.length ? (
-                    <p className="text-xs text-slate-500">
-                      Showing latest {formatCount(pendingApprovalItems.length)} of{" "}
-                      {formatCount(pendingApprovalsTotal)} pending approvals.
-                    </p>
-                  ) : null}
-                </div>
-              ) : (
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
-                  No pending approvals across your boards.
-                </div>
-              )}
-            </section>
-
-            <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-              <section className="min-w-0 overflow-hidden rounded-xl border border-slate-200 bg-white p-4 md:p-6 shadow-sm">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <h3 className="text-lg font-semibold text-slate-900">Sessions</h3>
-                  <span className="text-xs text-slate-500">{formatCount(activeSessions)}</span>
-                </div>
-                <div className="max-h-[310px] space-y-2 overflow-x-hidden overflow-y-auto pr-1">
-                  {!hasConfiguredGateways ? (
-                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-500">
-                      No gateways are configured for any board yet.
-                    </div>
-                  ) : gatewayStatusesQuery.isLoading ? (
-                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-500">
-                      Loading sessions...
-                    </div>
-                  ) : sessionSummaries.length > 0 ? (
-                    <>
-                      {gatewayUnavailableCount > 0 ? (
-                        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
-                          {formatCount(gatewayUnavailableCount)} gateway
-                          {gatewayUnavailableCount === 1 ? "" : "s"} unavailable; showing sessions
-                          from reachable gateways.
-                        </div>
-                      ) : null}
-                      {sessionSummaries.map((session) => (
-                        <div
-                          key={session.key}
-                          className="overflow-hidden rounded-lg border border-slate-200 bg-white px-3 py-2"
-                        >
-                          <div className="flex items-center justify-between gap-3">
-                            <div className="min-w-0 flex-1">
-                              <p className="truncate text-sm font-medium text-slate-900">
-                                <span
-                                  className={`mr-2 inline-block h-2 w-2 rounded-full ${
-                                    session.isMain ? "bg-emerald-500" : "bg-slate-400"
-                                  }`}
-                                />
-                                {session.title}
-                              </p>
-                              <p className="mt-0.5 truncate text-xs text-slate-500">{session.subtitle}</p>
-                            </div>
-                            <div className="min-w-0 max-w-[45%] text-right">
-                              <p className="truncate text-xs font-medium text-slate-700">
-                                {session.usage === DASH ? "Usage unavailable" : session.usage}
-                              </p>
-                              <p className="text-[11px] text-slate-500">
-                                {session.lastSeenAt
-                                  ? formatRelativeTimestamp(session.lastSeenAt)
-                                  : "Activity unavailable"}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </>
-                  ) : gatewayUnavailableCount === gatewayTargets.length ? (
-                    <div className="rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-700">
-                      Session data is unavailable for all configured gateways.
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-500">
-                      No active sessions detected.
-                    </div>
-                  )}
-                </div>
-              </section>
-
-              <section className="min-w-0 overflow-hidden rounded-xl border border-slate-200 bg-white p-4 md:p-6 shadow-sm">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <h3 className="text-lg font-semibold text-slate-900">Recent Activity</h3>
-                  <Link
-                    href={activityFeedHref}
-                    className="inline-flex items-center gap-1 text-xs text-slate-500 transition hover:text-slate-700"
-                  >
-                    Open feed
-                    <ArrowUpRight className="h-3.5 w-3.5" />
-                  </Link>
-                </div>
-                <div className="max-h-[310px] space-y-2 overflow-x-hidden overflow-y-auto pr-1">
-                  {recentLogs.length > 0 ? (
-                    recentLogs.map((event) => {
-                      const eventHref = buildActivityEventHref(event);
-                      return (
-                        <div
-                          key={event.id}
-                          role="link"
-                          tabIndex={0}
-                        aria-label={`Open related context for ${event.event_type} activity`}
-                          onClick={(interactionEvent) =>
-                            handleLogRowClick(interactionEvent, eventHref)
-                          }
-                          onKeyDown={(interactionEvent) =>
-                            handleLogRowKeyDown(interactionEvent, eventHref)
-                          }
-                          className="cursor-pointer overflow-hidden rounded-lg border border-slate-200 bg-white px-3 py-2 transition hover:border-slate-300 focus-visible:border-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0 flex-1 overflow-hidden">
-                              <div className="break-words text-sm font-medium text-slate-900 [&_ol]:mb-0 [&_p]:mb-0 [&_pre]:my-1 [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_ul]:mb-0">
-                                <Markdown
-                                  content={event.message?.trim() || event.event_type}
-                                  variant="comment"
-                                />
-                              </div>
-                              <p className="mt-0.5 text-xs uppercase tracking-wider text-slate-500">
-                                {event.event_type}
-                              </p>
-                            </div>
-                            <div className="shrink-0 text-right text-[11px] text-slate-500">
-                              <p>{formatRelativeTimestamp(event.created_at)}</p>
-                              <p>{formatTimestamp(event.created_at)}</p>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })
-                  ) : (
-                    <div className="flex h-[240px] flex-col items-center justify-center rounded-lg border border-slate-200 bg-white text-sm text-slate-500">
-                      <Shield className="mb-2 h-5 w-5 text-slate-400" />
-                      No activity yet
-                      <p className="mt-1 text-xs text-slate-500">Activity appears here when events are emitted.</p>
-                    </div>
-                  )}
+            <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+              <QuickActions />
+              <section className="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-slate-100 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-300">
+                  Belle daily briefing
+                </p>
+                <h3 className="mt-2 font-heading text-xl font-semibold">
+                  Service Pro accounts grew 6.2% this week
+                </h3>
+                <p className="mt-2 text-sm text-slate-300">
+                  Belle handled 1,284 inbound calls, booked 412 jobs, sent 387 estimates,
+                  and recovered $12,480 in late invoices. Roofing and HVAC verticals are
+                  driving most of the growth — Belle suggests staffing extra capacity on the
+                  estimate-follow-up cadence next week.
+                </p>
+                <div className="mt-4 flex flex-wrap gap-3 text-xs">
+                  <span className="rounded-full bg-white/10 px-3 py-1">1,284 calls</span>
+                  <span className="rounded-full bg-white/10 px-3 py-1">412 jobs booked</span>
+                  <span className="rounded-full bg-white/10 px-3 py-1">387 estimates</span>
+                  <span className="rounded-full bg-white/10 px-3 py-1">$12.48k recovered</span>
                 </div>
               </section>
             </div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,8 +10,9 @@ import { QueryProvider } from "@/components/providers/QueryProvider";
 import { GlobalLoader } from "@/components/ui/global-loader";
 
 export const metadata: Metadata = {
-  title: "OpenClaw Mission Control",
-  description: "A calm command center for every task.",
+  title: "Simple Pro Mission Control",
+  description:
+    "Mission control for the AI team building and operating Simple Pro — Belle, agents, boards, and approvals in one calm command center.",
 };
 
 const bodyFont = IBM_Plex_Sans({

--- a/frontend/src/components/atoms/BrandMark.tsx
+++ b/frontend/src/components/atoms/BrandMark.tsx
@@ -1,12 +1,12 @@
 export function BrandMark() {
   return (
     <div className="flex items-center gap-3">
-      <div className="grid h-10 w-10 place-items-center rounded-lg bg-gradient-to-br from-blue-600 to-blue-700 text-xs font-semibold text-white shadow-sm">
-        <span className="font-heading tracking-[0.2em]">OC</span>
+      <div className="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-indigo-600 via-blue-600 to-sky-500 text-sm font-semibold text-white shadow-sm">
+        <span className="font-heading tracking-[0.18em]">SP</span>
       </div>
       <div className="leading-tight">
-        <div className="font-heading text-sm uppercase tracking-[0.26em] text-strong">
-          OPENCLAW
+        <div className="font-heading text-sm font-semibold uppercase tracking-[0.22em] text-strong">
+          Simple Pro
         </div>
         <div className="text-[11px] font-medium text-quiet">
           Mission Control

--- a/frontend/src/components/mission-control/AgentTable.tsx
+++ b/frontend/src/components/mission-control/AgentTable.tsx
@@ -1,0 +1,144 @@
+import { MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { AgentStatus, SimpleProAgent } from "./mockTeam";
+
+const STATUS_STYLES: Record<AgentStatus, { dot: string; chip: string; label: string }> = {
+  active: {
+    dot: "bg-emerald-500",
+    chip: "bg-emerald-50 text-emerald-700",
+    label: "Active",
+  },
+  idle: {
+    dot: "bg-slate-400",
+    chip: "bg-slate-100 text-slate-600",
+    label: "Idle",
+  },
+  review: {
+    dot: "bg-violet-500",
+    chip: "bg-violet-50 text-violet-700",
+    label: "In review",
+  },
+  blocked: {
+    dot: "bg-rose-500",
+    chip: "bg-rose-50 text-rose-700",
+    label: "Blocked",
+  },
+  offline: {
+    dot: "bg-slate-300",
+    chip: "bg-slate-100 text-slate-500",
+    label: "Offline",
+  },
+};
+
+export type AgentTableProps = {
+  agents: SimpleProAgent[];
+};
+
+export function AgentTable({ agents }: AgentTableProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">AI Agents</h3>
+          <p className="text-xs text-slate-500">
+            Live roster of the Simple Pro AI team and what they&apos;re working on.
+          </p>
+        </div>
+        <span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700">
+          {agents.length} agents
+        </span>
+      </header>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-100 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+              <th className="px-5 py-3">Agent</th>
+              <th className="px-3 py-3">Platform</th>
+              <th className="px-3 py-3">Current task</th>
+              <th className="px-3 py-3">Status</th>
+              <th className="px-3 py-3 w-44">Progress</th>
+              <th className="px-3 py-3">Last activity</th>
+              <th className="px-5 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {agents.map((agent) => {
+              const status = STATUS_STYLES[agent.status];
+              return (
+                <tr key={agent.id} className="transition hover:bg-slate-50">
+                  <td className="px-5 py-3">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={cn(
+                          "grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-gradient-to-br text-xs font-semibold text-white shadow-sm",
+                          agent.accent,
+                        )}
+                      >
+                        {agent.initials}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-slate-900">
+                          {agent.name}
+                        </p>
+                        <p className="truncate text-xs text-slate-500">{agent.role}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <p className="font-medium text-slate-800">{agent.platform}</p>
+                    <p className="text-xs text-slate-500">{agent.model}</p>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <p className="max-w-[280px] truncate text-slate-700" title={agent.currentTask}>
+                      {agent.currentTask}
+                    </p>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium",
+                        status.chip,
+                      )}
+                    >
+                      <span className={cn("h-1.5 w-1.5 rounded-full", status.dot)} />
+                      {status.label}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <div className="flex items-center gap-2">
+                      <div className="h-1.5 w-full max-w-[120px] rounded-full bg-slate-100">
+                        <div
+                          className={cn(
+                            "h-1.5 rounded-full bg-gradient-to-r",
+                            agent.accent,
+                          )}
+                          style={{ width: `${Math.max(4, Math.min(100, agent.progress))}%` }}
+                        />
+                      </div>
+                      <span className="w-9 text-right text-xs font-medium text-slate-600">
+                        {agent.progress}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top text-xs text-slate-500">
+                    {agent.lastActivity}
+                  </td>
+                  <td className="px-5 py-3 text-right align-top">
+                    <button
+                      type="button"
+                      className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                      aria-label={`Actions for ${agent.name}`}
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/ApprovalsQueue.tsx
+++ b/frontend/src/components/mission-control/ApprovalsQueue.tsx
@@ -1,0 +1,82 @@
+import { Check, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ApprovalItem } from "./mockTeam";
+
+const RISK_TONE: Record<ApprovalItem["risk"], string> = {
+  low: "bg-emerald-50 text-emerald-700",
+  medium: "bg-amber-50 text-amber-700",
+  high: "bg-rose-50 text-rose-700",
+};
+
+const RISK_LABEL: Record<ApprovalItem["risk"], string> = {
+  low: "Low risk",
+  medium: "Medium risk",
+  high: "High risk",
+};
+
+export type ApprovalsQueueProps = {
+  items: ApprovalItem[];
+};
+
+export function ApprovalsQueue({ items }: ApprovalsQueueProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Approvals Queue</h3>
+          <p className="text-xs text-slate-500">
+            Decisions waiting on a human before agents can proceed.
+          </p>
+        </div>
+        <span className="rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-semibold text-amber-700">
+          {items.length} pending
+        </span>
+      </header>
+      <ul className="divide-y divide-slate-100">
+        {items.map((item) => (
+          <li key={item.id} className="px-5 py-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-slate-900">{item.title}</p>
+                <p className="mt-0.5 text-xs text-slate-500">
+                  {item.agent} · {item.scope} · {item.raised}
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                  RISK_TONE[item.risk],
+                )}
+              >
+                {RISK_LABEL[item.risk]}
+              </span>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 px-2.5 py-1 text-xs font-medium text-white transition hover:bg-emerald-700"
+              >
+                <Check className="h-3 w-3" />
+                Approve
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+              >
+                <X className="h-3 w-3" />
+                Reject
+              </button>
+              <button
+                type="button"
+                className="ml-auto text-xs font-medium text-slate-500 transition hover:text-slate-700"
+              >
+                View context
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/BelleInsights.tsx
+++ b/frontend/src/components/mission-control/BelleInsights.tsx
@@ -1,0 +1,77 @@
+import { Sparkles, AlertTriangle, TrendingUp, Info } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { BelleInsight } from "./mockTeam";
+
+const TONE_STYLES: Record<BelleInsight["tone"], { icon: React.ElementType; chip: string; ring: string }> = {
+  info: { icon: Info, chip: "bg-blue-50 text-blue-700", ring: "ring-blue-100" },
+  warning: { icon: AlertTriangle, chip: "bg-amber-50 text-amber-700", ring: "ring-amber-100" },
+  success: { icon: TrendingUp, chip: "bg-emerald-50 text-emerald-700", ring: "ring-emerald-100" },
+};
+
+export type BelleInsightsProps = {
+  insights: BelleInsight[];
+};
+
+export function BelleInsights({ insights }: BelleInsightsProps) {
+  return (
+    <section className="flex h-full flex-col rounded-2xl border border-slate-200 bg-gradient-to-br from-fuchsia-50/60 via-white to-violet-50/40 shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <span className="grid h-9 w-9 place-items-center rounded-xl bg-gradient-to-br from-fuchsia-500 to-purple-600 text-white shadow-sm">
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <div>
+            <h3 className="text-base font-semibold text-slate-900">Belle Insights</h3>
+            <p className="text-xs text-slate-500">
+              What Belle is learning from the field this week.
+            </p>
+          </div>
+        </div>
+        <span className="rounded-full bg-purple-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-purple-700">
+          Live
+        </span>
+      </header>
+      <div className="flex-1 space-y-3 overflow-y-auto px-5 py-4">
+        {insights.map((insight) => {
+          const tone = TONE_STYLES[insight.tone];
+          const Icon = tone.icon;
+          return (
+            <article
+              key={insight.id}
+              className={cn(
+                "rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm ring-1 backdrop-blur",
+                tone.ring,
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  className={cn(
+                    "grid h-8 w-8 shrink-0 place-items-center rounded-lg",
+                    tone.chip,
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900">{insight.title}</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600">
+                    {insight.detail}
+                  </p>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+      <footer className="border-t border-slate-100 px-5 py-3">
+        <button
+          type="button"
+          className="w-full rounded-lg bg-slate-900 px-3 py-2 text-xs font-medium text-white shadow-sm transition hover:bg-slate-800"
+        >
+          Ask Belle a question
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/MissionControlHeader.tsx
+++ b/frontend/src/components/mission-control/MissionControlHeader.tsx
@@ -1,0 +1,89 @@
+import { Bell, ChevronDown, Sparkles, Activity } from "lucide-react";
+
+export type MissionControlHeaderProps = {
+  workspace?: string;
+  notificationCount?: number;
+  belleStatus?: "online" | "degraded" | "offline";
+  belleLatencyMs?: number;
+  belleActiveSessions?: number;
+};
+
+export function MissionControlHeader({
+  workspace = "Simple Pro · Production",
+  notificationCount = 5,
+  belleStatus = "online",
+  belleLatencyMs = 312,
+  belleActiveSessions = 14,
+}: MissionControlHeaderProps) {
+  const statusColor =
+    belleStatus === "online"
+      ? "bg-emerald-500"
+      : belleStatus === "degraded"
+        ? "bg-amber-500"
+        : "bg-rose-500";
+  const statusLabel =
+    belleStatus === "online"
+      ? "Online"
+      : belleStatus === "degraded"
+        ? "Degraded"
+        : "Offline";
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:flex-row md:items-center md:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-blue-600">
+          <Activity className="h-3.5 w-3.5" />
+          Mission Control
+        </div>
+        <h1 className="mt-1 font-heading text-2xl font-bold text-slate-900 md:text-3xl">
+          Simple Pro Mission Control
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Belle, agents, and the production stack — one calm command center for the AI team
+          building Simple Pro.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
+        >
+          <span className="grid h-6 w-6 place-items-center rounded-md bg-gradient-to-br from-indigo-500 to-blue-600 text-[10px] font-semibold text-white">
+            SP
+          </span>
+          <span className="max-w-[180px] truncate">{workspace}</span>
+          <ChevronDown className="h-4 w-4 text-slate-400" />
+        </button>
+
+        <button
+          type="button"
+          className="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
+          aria-label="Notifications"
+        >
+          <Bell className="h-4 w-4" />
+          {notificationCount > 0 ? (
+            <span className="absolute -right-1 -top-1 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-semibold text-white">
+              {notificationCount}
+            </span>
+          ) : null}
+        </button>
+
+        <div className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-gradient-to-br from-fuchsia-50 via-white to-violet-50 px-4 py-2 shadow-sm">
+          <span className="grid h-9 w-9 place-items-center rounded-xl bg-gradient-to-br from-fuchsia-500 to-purple-600 text-white shadow-sm">
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <div className="leading-tight">
+            <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-purple-700">
+              <span className={`h-1.5 w-1.5 rounded-full ${statusColor}`} />
+              Belle Orchestrator · {statusLabel}
+            </div>
+            <div className="text-xs text-slate-600">
+              {belleActiveSessions} sessions · {belleLatencyMs}ms p50
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/mission-control/QuickActions.tsx
+++ b/frontend/src/components/mission-control/QuickActions.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import {
+  Bot,
+  CheckCircle2,
+  LayoutGrid,
+  MessageCircle,
+  Rocket,
+  Sparkles,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type Action = {
+  id: string;
+  label: string;
+  description: string;
+  href: string;
+  icon: React.ElementType;
+  accent: string;
+};
+
+const ACTIONS: Action[] = [
+  {
+    id: "talk-belle",
+    label: "Talk to Belle",
+    description: "Voice + chat command line",
+    href: "/dashboard",
+    icon: MessageCircle,
+    accent: "from-fuchsia-500 to-purple-600",
+  },
+  {
+    id: "review-approvals",
+    label: "Review approvals",
+    description: "Pending agent decisions",
+    href: "/approvals",
+    icon: CheckCircle2,
+    accent: "from-emerald-500 to-teal-500",
+  },
+  {
+    id: "ship-deploy",
+    label: "Ship a deploy",
+    description: "Promote canary to prod",
+    href: "/dashboard",
+    icon: Rocket,
+    accent: "from-blue-500 to-sky-500",
+  },
+  {
+    id: "open-board",
+    label: "Open a board",
+    description: "Hop into team workspace",
+    href: "/boards",
+    icon: LayoutGrid,
+    accent: "from-amber-500 to-orange-500",
+  },
+  {
+    id: "manage-agents",
+    label: "Manage agents",
+    description: "Tune the AI team roster",
+    href: "/agents",
+    icon: Bot,
+    accent: "from-indigo-500 to-violet-500",
+  },
+  {
+    id: "ask-insight",
+    label: "Generate insight",
+    description: "Ask Belle for a summary",
+    href: "/dashboard",
+    icon: Sparkles,
+    accent: "from-pink-500 to-rose-500",
+  },
+];
+
+export function QuickActions() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Quick Actions</h3>
+          <p className="text-xs text-slate-500">Shortcuts into the most common workflows.</p>
+        </div>
+      </header>
+      <div className="grid grid-cols-2 gap-2 p-4">
+        {ACTIONS.map((action) => {
+          const Icon = action.icon;
+          return (
+            <Link
+              key={action.id}
+              href={action.href}
+              className="group flex items-start gap-3 rounded-xl border border-slate-100 bg-slate-50/60 p-3 transition hover:-translate-y-0.5 hover:border-slate-200 hover:bg-white hover:shadow-sm"
+            >
+              <span
+                className={cn(
+                  "grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-gradient-to-br text-white shadow-sm",
+                  action.accent,
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-slate-900">{action.label}</p>
+                <p className="mt-0.5 text-[11px] text-slate-500">{action.description}</p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/RecentActivity.tsx
+++ b/frontend/src/components/mission-control/RecentActivity.tsx
@@ -1,0 +1,82 @@
+import {
+  Code2,
+  Phone,
+  Rocket,
+  ShieldCheck,
+  TriangleAlert,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ActivityItem } from "./mockTeam";
+
+const KIND_ICON: Record<ActivityItem["kind"], React.ElementType> = {
+  deploy: Rocket,
+  approval: ShieldCheck,
+  code: Code2,
+  voice: Phone,
+  alert: TriangleAlert,
+};
+
+const KIND_TONE: Record<ActivityItem["kind"], string> = {
+  deploy: "bg-blue-50 text-blue-600",
+  approval: "bg-emerald-50 text-emerald-600",
+  code: "bg-violet-50 text-violet-600",
+  voice: "bg-fuchsia-50 text-fuchsia-600",
+  alert: "bg-amber-50 text-amber-600",
+};
+
+export type RecentActivityProps = {
+  items: ActivityItem[];
+};
+
+export function RecentActivity({ items }: RecentActivityProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Recent Activity</h3>
+          <p className="text-xs text-slate-500">
+            Pulse from agents, Belle, and the production stack.
+          </p>
+        </div>
+      </header>
+      <ul className="divide-y divide-slate-100">
+        {items.map((item) => {
+          const Icon = KIND_ICON[item.kind];
+          return (
+            <li key={item.id} className="flex items-start gap-3 px-5 py-3">
+              <span
+                className={cn(
+                  "mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-lg",
+                  KIND_TONE[item.kind],
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-800">
+                  <span
+                    className={cn(
+                      "mr-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-gradient-to-br text-[10px] font-semibold text-white",
+                      item.agentAccent,
+                    )}
+                  >
+                    {item.agent
+                      .split(" ")
+                      .slice(0, 2)
+                      .map((part) => part[0])
+                      .join("")
+                      .toUpperCase()}
+                  </span>
+                  <span className="font-medium text-slate-900">{item.agent}</span>{" "}
+                  <span className="text-slate-700">{item.message}</span>
+                </p>
+                <p className="mt-0.5 text-[11px] text-slate-500">{item.time}</p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/ReposDeployments.tsx
+++ b/frontend/src/components/mission-control/ReposDeployments.tsx
@@ -1,0 +1,75 @@
+import { GitBranch, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { RepoDeployment } from "./mockTeam";
+
+const STATUS_STYLES: Record<RepoDeployment["status"], string> = {
+  deployed: "bg-emerald-50 text-emerald-700",
+  deploying: "bg-blue-50 text-blue-700 animate-pulse",
+  failed: "bg-rose-50 text-rose-700",
+  queued: "bg-slate-100 text-slate-600",
+};
+
+const STATUS_LABEL: Record<RepoDeployment["status"], string> = {
+  deployed: "Deployed",
+  deploying: "Deploying",
+  failed: "Failed",
+  queued: "Queued",
+};
+
+export type ReposDeploymentsProps = {
+  items: RepoDeployment[];
+};
+
+export function ReposDeployments({ items }: ReposDeploymentsProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Repos &amp; Deployments</h3>
+          <p className="text-xs text-slate-500">Latest pushes across the Simple Pro stack.</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 transition hover:text-slate-700"
+        >
+          View all
+          <ArrowUpRight className="h-3.5 w-3.5" />
+        </button>
+      </header>
+      <ul className="divide-y divide-slate-100">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            className="flex items-center justify-between gap-3 px-5 py-3 transition hover:bg-slate-50"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-slate-900">{item.repo}</p>
+              <p className="mt-0.5 flex items-center gap-1.5 text-xs text-slate-500">
+                <GitBranch className="h-3 w-3" />
+                <span className="truncate">{item.branch}</span>
+                <span>·</span>
+                <span>{item.env}</span>
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium",
+                    STATUS_STYLES[item.status],
+                  )}
+                >
+                  {STATUS_LABEL[item.status]}
+                </span>
+                <p className="mt-0.5 text-[11px] text-slate-500">
+                  {item.lastDeploy} · {item.by}
+                </p>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/StatCard.tsx
+++ b/frontend/src/components/mission-control/StatCard.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type Accent = "blue" | "emerald" | "violet" | "amber";
+
+const ACCENT_STYLES: Record<Accent, { icon: string; trend: string }> = {
+  blue: {
+    icon: "bg-blue-50 text-blue-600",
+    trend: "text-blue-600",
+  },
+  emerald: {
+    icon: "bg-emerald-50 text-emerald-600",
+    trend: "text-emerald-600",
+  },
+  violet: {
+    icon: "bg-violet-50 text-violet-600",
+    trend: "text-violet-600",
+  },
+  amber: {
+    icon: "bg-amber-50 text-amber-600",
+    trend: "text-amber-600",
+  },
+};
+
+export type StatCardProps = {
+  title: string;
+  value: string;
+  trend?: string;
+  trendDirection?: "up" | "down" | "flat";
+  subtitle?: string;
+  icon: ReactNode;
+  accent?: Accent;
+};
+
+export function StatCard({
+  title,
+  value,
+  trend,
+  trendDirection = "up",
+  subtitle,
+  icon,
+  accent = "blue",
+}: StatCardProps) {
+  const tone = ACCENT_STYLES[accent];
+
+  return (
+    <section className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+            {title}
+          </p>
+          <p className="mt-2 font-heading text-3xl font-bold text-slate-900">
+            {value}
+          </p>
+          {subtitle ? (
+            <p className="mt-1 text-xs text-slate-500">{subtitle}</p>
+          ) : null}
+        </div>
+        <div
+          className={cn(
+            "grid h-10 w-10 shrink-0 place-items-center rounded-xl",
+            tone.icon,
+          )}
+        >
+          {icon}
+        </div>
+      </div>
+      {trend ? (
+        <div className="mt-4 flex items-center gap-2 text-xs">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+              trendDirection === "up" && "bg-emerald-50 text-emerald-700",
+              trendDirection === "down" && "bg-rose-50 text-rose-700",
+              trendDirection === "flat" && "bg-slate-100 text-slate-600",
+            )}
+          >
+            {trendDirection === "up" ? "▲" : trendDirection === "down" ? "▼" : "▬"}
+            {trend}
+          </span>
+          <span className="text-slate-500">vs last 7 days</span>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/TaskPipeline.tsx
+++ b/frontend/src/components/mission-control/TaskPipeline.tsx
@@ -1,0 +1,100 @@
+import { Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { PipelineCard, PipelineColumn } from "./mockTeam";
+
+const TAG_TONES: Record<PipelineCard["tagTone"], string> = {
+  blue: "bg-blue-50 text-blue-700",
+  violet: "bg-violet-50 text-violet-700",
+  emerald: "bg-emerald-50 text-emerald-700",
+  amber: "bg-amber-50 text-amber-700",
+  rose: "bg-rose-50 text-rose-700",
+  slate: "bg-slate-100 text-slate-600",
+};
+
+export type TaskPipelineProps = {
+  columns: PipelineColumn[];
+};
+
+export function TaskPipeline({ columns }: TaskPipelineProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Task Pipeline</h3>
+          <p className="text-xs text-slate-500">
+            Work flowing across the Simple Pro AI team this week.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New task
+        </button>
+      </header>
+      <div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2 xl:grid-cols-4">
+        {columns.map((column) => (
+          <div
+            key={column.id}
+            className="flex min-h-[260px] flex-col rounded-xl border border-slate-100 bg-slate-50/60 p-3"
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className={cn("h-2 w-2 rounded-full", column.accent)} />
+                <h4 className="text-sm font-semibold text-slate-800">
+                  {column.title}
+                </h4>
+              </div>
+              <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-500 shadow-sm">
+                {column.cards.length}
+              </span>
+            </div>
+            <div className="flex-1 space-y-2">
+              {column.cards.map((card) => (
+                <article
+                  key={card.id}
+                  className="group cursor-pointer rounded-lg border border-slate-200 bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="text-sm font-medium leading-snug text-slate-800">
+                      {card.title}
+                    </p>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between gap-2 text-xs">
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-0.5 font-medium",
+                        TAG_TONES[card.tagTone],
+                      )}
+                    >
+                      {card.tag}
+                    </span>
+                    <span className="text-slate-500">{card.meta}</span>
+                  </div>
+                  <div className="mt-3 flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "grid h-6 w-6 place-items-center rounded-full bg-gradient-to-br text-[10px] font-semibold text-white",
+                        card.ownerAccent,
+                      )}
+                    >
+                      {card.owner
+                        .split(" ")
+                        .slice(0, 2)
+                        .map((part) => part[0])
+                        .join("")
+                        .toUpperCase()}
+                    </span>
+                    <span className="truncate text-xs text-slate-600">{card.owner}</span>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/mission-control/mockTeam.ts
+++ b/frontend/src/components/mission-control/mockTeam.ts
@@ -1,0 +1,438 @@
+export type AgentStatus = "active" | "idle" | "review" | "blocked" | "offline";
+
+export type SimpleProAgent = {
+  id: string;
+  name: string;
+  role: string;
+  initials: string;
+  accent: string;
+  platform: string;
+  model: string;
+  currentTask: string;
+  status: AgentStatus;
+  progress: number;
+  lastActivity: string;
+};
+
+export const SIMPLE_PRO_AGENTS: SimpleProAgent[] = [
+  {
+    id: "openclaw-coordinator",
+    name: "OpenClaw Coordinator",
+    role: "Orchestrator",
+    initials: "OC",
+    accent: "from-indigo-500 to-violet-500",
+    platform: "OpenClaw",
+    model: "claude-opus-4-7",
+    currentTask: "Routing Belle voice intents to scheduler",
+    status: "active",
+    progress: 72,
+    lastActivity: "2m ago",
+  },
+  {
+    id: "claude-code-cto",
+    name: "Claude Code CTO",
+    role: "Architect / CTO",
+    initials: "CC",
+    accent: "from-amber-500 to-orange-500",
+    platform: "Claude Code",
+    model: "claude-opus-4-7",
+    currentTask: "Reviewing payments retry policy for late invoices",
+    status: "review",
+    progress: 58,
+    lastActivity: "6m ago",
+  },
+  {
+    id: "codex-builder",
+    name: "Codex Builder",
+    role: "Senior Engineer",
+    initials: "CB",
+    accent: "from-emerald-500 to-teal-500",
+    platform: "OpenAI Codex",
+    model: "gpt-5.1-codex",
+    currentTask: "Implementing technician photo diagnosis upload flow",
+    status: "active",
+    progress: 84,
+    lastActivity: "just now",
+  },
+  {
+    id: "hermes-qa",
+    name: "Hermes QA",
+    role: "QA / Test Pilot",
+    initials: "HQ",
+    accent: "from-sky-500 to-blue-500",
+    platform: "Hermes",
+    model: "claude-sonnet-4-6",
+    currentTask: "End-to-end test: estimate → invoice → Stripe collect",
+    status: "active",
+    progress: 41,
+    lastActivity: "1m ago",
+  },
+  {
+    id: "devops-agent",
+    name: "DevOps Agent",
+    role: "Platform / Infra",
+    initials: "DO",
+    accent: "from-slate-500 to-slate-700",
+    platform: "Internal",
+    model: "claude-sonnet-4-6",
+    currentTask: "Promoting Belle voice gateway to canary",
+    status: "idle",
+    progress: 100,
+    lastActivity: "14m ago",
+  },
+  {
+    id: "product-design-agent",
+    name: "Product / Design Agent",
+    role: "Product & UX",
+    initials: "PD",
+    accent: "from-pink-500 to-rose-500",
+    platform: "Figma + Claude",
+    model: "claude-opus-4-7",
+    currentTask: "Refining technician daily-route mobile screens",
+    status: "active",
+    progress: 63,
+    lastActivity: "9m ago",
+  },
+  {
+    id: "belle-product-assistant",
+    name: "Belle Product Assistant",
+    role: "Product Companion",
+    initials: "BL",
+    accent: "from-fuchsia-500 to-purple-500",
+    platform: "Belle",
+    model: "claude-opus-4-7",
+    currentTask: "Drafting follow-up scripts for late-payment customers",
+    status: "active",
+    progress: 49,
+    lastActivity: "30s ago",
+  },
+];
+
+export type PipelineColumn = {
+  id: "backlog" | "in-progress" | "review" | "done";
+  title: string;
+  accent: string;
+  cards: PipelineCard[];
+};
+
+export type PipelineCard = {
+  id: string;
+  title: string;
+  owner: string;
+  ownerAccent: string;
+  tag: string;
+  tagTone: "blue" | "violet" | "emerald" | "amber" | "rose" | "slate";
+  meta: string;
+};
+
+export const TASK_PIPELINE: PipelineColumn[] = [
+  {
+    id: "backlog",
+    title: "Backlog",
+    accent: "bg-slate-400",
+    cards: [
+      {
+        id: "bk-1",
+        title: "Receipt OCR — multi-page PDF support",
+        owner: "Codex Builder",
+        ownerAccent: "from-emerald-500 to-teal-500",
+        tag: "Belle",
+        tagTone: "violet",
+        meta: "Receipts · 3 pts",
+      },
+      {
+        id: "bk-2",
+        title: "Tech app — offline job notes sync",
+        owner: "Product / Design",
+        ownerAccent: "from-pink-500 to-rose-500",
+        tag: "Mobile",
+        tagTone: "blue",
+        meta: "Field Ops · 5 pts",
+      },
+      {
+        id: "bk-3",
+        title: "QuickBooks payout reconciliation v2",
+        owner: "Claude Code CTO",
+        ownerAccent: "from-amber-500 to-orange-500",
+        tag: "Payments",
+        tagTone: "amber",
+        meta: "Billing · 8 pts",
+      },
+    ],
+  },
+  {
+    id: "in-progress",
+    title: "In Progress",
+    accent: "bg-blue-500",
+    cards: [
+      {
+        id: "ip-1",
+        title: "Belle voice → schedule appointment intent",
+        owner: "OpenClaw Coordinator",
+        ownerAccent: "from-indigo-500 to-violet-500",
+        tag: "Voice",
+        tagTone: "violet",
+        meta: "Belle · 5 pts",
+      },
+      {
+        id: "ip-2",
+        title: "Photo diagnosis: HVAC compressor classifier",
+        owner: "Codex Builder",
+        ownerAccent: "from-emerald-500 to-teal-500",
+        tag: "AI",
+        tagTone: "emerald",
+        meta: "Diagnostics · 8 pts",
+      },
+      {
+        id: "ip-3",
+        title: "Late-payment follow-up cadence v3",
+        owner: "Belle Assistant",
+        ownerAccent: "from-fuchsia-500 to-purple-500",
+        tag: "Payments",
+        tagTone: "amber",
+        meta: "Collections · 3 pts",
+      },
+    ],
+  },
+  {
+    id: "review",
+    title: "Review",
+    accent: "bg-violet-500",
+    cards: [
+      {
+        id: "rv-1",
+        title: "Estimate PDF template — branded edition",
+        owner: "Hermes QA",
+        ownerAccent: "from-sky-500 to-blue-500",
+        tag: "Estimates",
+        tagTone: "blue",
+        meta: "Awaiting CTO · 2 pts",
+      },
+      {
+        id: "rv-2",
+        title: "Stripe webhook idempotency hardening",
+        owner: "Claude Code CTO",
+        ownerAccent: "from-amber-500 to-orange-500",
+        tag: "Payments",
+        tagTone: "amber",
+        meta: "Awaiting QA · 5 pts",
+      },
+    ],
+  },
+  {
+    id: "done",
+    title: "Done",
+    accent: "bg-emerald-500",
+    cards: [
+      {
+        id: "dn-1",
+        title: "Inbound call routing for after-hours",
+        owner: "OpenClaw Coordinator",
+        ownerAccent: "from-indigo-500 to-violet-500",
+        tag: "Voice",
+        tagTone: "violet",
+        meta: "Shipped · 3 pts",
+      },
+      {
+        id: "dn-2",
+        title: "Job task → invoice line items mapper",
+        owner: "Codex Builder",
+        ownerAccent: "from-emerald-500 to-teal-500",
+        tag: "Billing",
+        tagTone: "amber",
+        meta: "Shipped · 5 pts",
+      },
+    ],
+  },
+];
+
+export type BelleInsight = {
+  id: string;
+  title: string;
+  detail: string;
+  tone: "info" | "warning" | "success";
+};
+
+export const BELLE_INSIGHTS: BelleInsight[] = [
+  {
+    id: "insight-1",
+    title: "Calls peaking 8–10 AM",
+    detail:
+      "Belle is handling 3.4× more inbound calls weekday mornings. Recommend pre-warming voice gateway capacity before 7:45 AM local.",
+    tone: "info",
+  },
+  {
+    id: "insight-2",
+    title: "Late-invoice follow-ups recovering 38%",
+    detail:
+      "New cadence (day 3 / day 7 / day 14) recovered $12,480 across 27 customers this week. Suggest rolling out to plumbing accounts next.",
+    tone: "success",
+  },
+  {
+    id: "insight-3",
+    title: "Photo diagnosis confidence dipped",
+    detail:
+      "HVAC compressor classifier confidence fell to 71% on rooftop units. Hermes QA is queuing labeled examples for retraining.",
+    tone: "warning",
+  },
+  {
+    id: "insight-4",
+    title: "Receipts uploaded by techs +22%",
+    detail:
+      "Field techs uploaded 412 receipts this week — Codex Builder is shipping multi-page PDF support to keep latency under 2s.",
+    tone: "info",
+  },
+];
+
+export type RepoDeployment = {
+  id: string;
+  repo: string;
+  branch: string;
+  status: "deployed" | "deploying" | "failed" | "queued";
+  env: string;
+  lastDeploy: string;
+  by: string;
+};
+
+export const REPOS_DEPLOYMENTS: RepoDeployment[] = [
+  {
+    id: "repo-1",
+    repo: "simplepro/web-app",
+    branch: "main",
+    status: "deployed",
+    env: "production",
+    lastDeploy: "12m ago",
+    by: "DevOps Agent",
+  },
+  {
+    id: "repo-2",
+    repo: "simplepro/belle-voice",
+    branch: "feat/canary",
+    status: "deploying",
+    env: "canary",
+    lastDeploy: "just now",
+    by: "DevOps Agent",
+  },
+  {
+    id: "repo-3",
+    repo: "simplepro/tech-mobile",
+    branch: "release/2026.05",
+    status: "deployed",
+    env: "staging",
+    lastDeploy: "1h ago",
+    by: "Codex Builder",
+  },
+  {
+    id: "repo-4",
+    repo: "simplepro/billing",
+    branch: "fix/stripe-idempotency",
+    status: "queued",
+    env: "preview",
+    lastDeploy: "—",
+    by: "Claude Code CTO",
+  },
+];
+
+export type ActivityItem = {
+  id: string;
+  agent: string;
+  agentAccent: string;
+  message: string;
+  time: string;
+  kind: "deploy" | "approval" | "code" | "voice" | "alert";
+};
+
+export const RECENT_ACTIVITY: ActivityItem[] = [
+  {
+    id: "act-1",
+    agent: "DevOps Agent",
+    agentAccent: "from-slate-500 to-slate-700",
+    message: "Promoted belle-voice to canary (build #4821).",
+    time: "30s ago",
+    kind: "deploy",
+  },
+  {
+    id: "act-2",
+    agent: "Hermes QA",
+    agentAccent: "from-sky-500 to-blue-500",
+    message: "All 184 e2e checks passing on payments suite.",
+    time: "3m ago",
+    kind: "code",
+  },
+  {
+    id: "act-3",
+    agent: "Belle",
+    agentAccent: "from-fuchsia-500 to-purple-500",
+    message: "Booked appointment for Acme Plumbing — Tue 9:30 AM.",
+    time: "6m ago",
+    kind: "voice",
+  },
+  {
+    id: "act-4",
+    agent: "Claude Code CTO",
+    agentAccent: "from-amber-500 to-orange-500",
+    message: "Approved PR #312 — Stripe webhook idempotency.",
+    time: "11m ago",
+    kind: "approval",
+  },
+  {
+    id: "act-5",
+    agent: "Codex Builder",
+    agentAccent: "from-emerald-500 to-teal-500",
+    message: "Pushed compressor-classifier v0.4 (+1.2% accuracy).",
+    time: "18m ago",
+    kind: "code",
+  },
+  {
+    id: "act-6",
+    agent: "OpenClaw Coordinator",
+    agentAccent: "from-indigo-500 to-violet-500",
+    message: "Reassigned 2 tasks from idle DevOps queue.",
+    time: "26m ago",
+    kind: "alert",
+  },
+];
+
+export type ApprovalItem = {
+  id: string;
+  title: string;
+  agent: string;
+  scope: string;
+  risk: "low" | "medium" | "high";
+  raised: string;
+};
+
+export const APPROVAL_QUEUE: ApprovalItem[] = [
+  {
+    id: "apv-1",
+    title: "Promote belle-voice canary to 100% production",
+    agent: "DevOps Agent",
+    scope: "Production deploy",
+    risk: "high",
+    raised: "2m ago",
+  },
+  {
+    id: "apv-2",
+    title: "Auto-charge invoices > 30 days late (HVAC pilot)",
+    agent: "Belle Assistant",
+    scope: "Billing policy",
+    risk: "medium",
+    raised: "12m ago",
+  },
+  {
+    id: "apv-3",
+    title: "Enable photo-diagnosis recommendations in tech app",
+    agent: "Product / Design",
+    scope: "Feature flag",
+    risk: "low",
+    raised: "34m ago",
+  },
+  {
+    id: "apv-4",
+    title: "Update QuickBooks token rotation cadence to 30d",
+    agent: "Claude Code CTO",
+    scope: "Integration",
+    risk: "low",
+    raised: "1h ago",
+  },
+];

--- a/frontend/src/components/organisms/DashboardSidebar.tsx
+++ b/frontend/src/components/organisms/DashboardSidebar.tsx
@@ -13,6 +13,7 @@ import {
   LayoutGrid,
   Network,
   Settings,
+  Sparkles,
   Store,
   Tags,
 } from "lucide-react";
@@ -24,6 +25,10 @@ import {
   type healthzHealthzGetResponse,
   useHealthzHealthzGet,
 } from "@/api/generated/default/default";
+import {
+  type getMeApiV1UsersMeGetResponse,
+  useGetMeApiV1UsersMeGet,
+} from "@/api/generated/users/users";
 import { cn } from "@/lib/utils";
 
 export function DashboardSidebar() {
@@ -40,6 +45,22 @@ export function DashboardSidebar() {
       request: { cache: "no-store" },
     },
   );
+  const meQuery = useGetMeApiV1UsersMeGet<getMeApiV1UsersMeGetResponse, ApiError>({
+    query: {
+      enabled: Boolean(isSignedIn),
+      retry: false,
+      refetchOnMount: "always",
+    },
+  });
+  const profile = meQuery.data?.status === 200 ? meQuery.data.data : null;
+  const userName = profile?.name ?? profile?.preferred_name ?? "Operator";
+  const userEmail = profile?.email ?? "";
+  const userInitials = userName
+    .split(" ")
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase() || "OP";
 
   const okValue = healthQuery.data?.data?.ok;
   const systemStatus: "unknown" | "operational" | "degraded" =
@@ -59,8 +80,19 @@ export function DashboardSidebar() {
 
   return (
     <aside className="fixed inset-y-0 left-0 z-40 flex w-[280px] -translate-x-full flex-col border-r border-slate-200 bg-white pt-16 shadow-lg transition-transform duration-200 ease-in-out [[data-sidebar=open]_&]:translate-x-0 md:relative md:inset-auto md:z-auto md:w-[260px] md:translate-x-0 md:pt-0 md:shadow-none md:transition-none">
-      <div className="flex-1 px-3 py-4">
-        <p className="px-3 text-xs font-semibold uppercase tracking-wider text-slate-500">
+      <div className="flex-1 overflow-y-auto px-3 py-4">
+        <div className="mx-1 mb-4 flex items-center gap-2 rounded-xl border border-slate-100 bg-gradient-to-br from-fuchsia-50 via-white to-violet-50 px-3 py-2.5 shadow-sm">
+          <span className="grid h-7 w-7 place-items-center rounded-lg bg-gradient-to-br from-fuchsia-500 to-purple-600 text-white shadow-sm">
+            <Sparkles className="h-3.5 w-3.5" />
+          </span>
+          <div className="min-w-0 leading-tight">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-purple-700">
+              Belle Orchestrator
+            </p>
+            <p className="truncate text-[11px] text-slate-500">All systems nominal</p>
+          </div>
+        </div>
+        <p className="px-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
           Navigation
         </p>
         <nav className="mt-3 space-y-4 text-sm">
@@ -252,8 +284,26 @@ export function DashboardSidebar() {
           </div>
         </nav>
       </div>
-      <div className="border-t border-slate-200 p-4">
-        <div className="flex items-center gap-2 text-xs text-slate-500">
+      <div className="border-t border-slate-200 p-3">
+        <div className="flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-2.5 shadow-sm">
+          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-gradient-to-br from-indigo-500 via-blue-600 to-sky-500 text-xs font-semibold text-white shadow-sm">
+            {userInitials}
+          </span>
+          <div className="min-w-0 leading-tight">
+            <p className="truncate text-sm font-medium text-slate-900">{userName}</p>
+            <p className="truncate text-[11px] text-slate-500">
+              {userEmail || (isAdmin ? "Workspace admin" : "Operator")}
+            </p>
+          </div>
+          <Link
+            href="/organization"
+            className="ml-auto rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+            aria-label="Open account settings"
+          >
+            <Settings className="h-4 w-4" />
+          </Link>
+        </div>
+        <div className="mt-3 flex items-center gap-2 px-2 text-[11px] text-slate-500">
           <span
             className={cn(
               "h-2 w-2 rounded-full",


### PR DESCRIPTION
## Task / context

Adapt the forked Mission Control repo into a Simple Pro-branded AI command center for managing the AI team building and operating Simple Pro.

## Why

The original dashboard was useful structurally but did not match Simple Pro’s product direction. This PR reframes the UI as a polished SaaS command center for agents, runs, approvals, deployments, and Belle-assisted team operations.

## Scope

- Rebrands the shell to **Simple Pro · Mission Control**
- Adds a polished sidebar with active states, Belle status, preserved nav routes, and user card
- Adds a Mission Control header with workspace selector, notification button, and Belle Orchestrator status
- Adds dashboard stat cards
- Adds AI Agents table
- Adds Task Pipeline kanban
- Adds Belle Insights panel
- Adds Repos & Deployments
- Adds Recent Activity
- Adds Approvals Queue
- Adds Quick Actions
- Preserves existing boards, agents, gateways, approvals, skills, backend logic, and live dashboard queries

### Out of scope

- No real Claude Code, Codex, Hermes, or OpenClaw integrations added yet
- No production deployment changes
- No database/schema changes
- No auth changes

## Evidence / validation

- Typecheck: clean
- Lint: clean
- Build: passed
- Tests: 115/115 passed

## Risk / rollout notes

Risk level: low-to-medium. This is primarily a UI/dashboard adaptation while preserving backend and orchestration behavior.

Rollback plan: revert this PR or restore the prior dashboard shell/components.

## Checklist

- [x] Branch created from `origin/master`
- [x] PR is focused on one theme
- [x] No secrets included
- [x] Existing boards, agents, gateways, approvals, and skills preserved
- [x] Build/lint/tests passed