### PR TITLE
fix: sync skill packs with configured branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Core operational areas:
 - Distributed runtime control: connect gateways and operate remote execution environments without changing operator workflow.
 - Audit and incident review: use activity history to reconstruct what happened, when it happened, and who initiated it.
 - API-backed process integration: connect internal workflows and automation clients to the same operational model used in the UI.
+- Governed X/Twitter automation: install a skill such as [TweetClaw](https://github.com/Xquik-dev/tweetclaw) on selected gateways, then review search tweets, search tweet replies, follower export, user lookup, monitor events, webhooks, giveaway draws, and approval-gated post or reply actions from the same operations surface.
 
 ## What makes Mission Control different
 
@@ -158,6 +159,10 @@ Environment templates:
 ## Documentation
 
 Complete guides for deployment, production, troubleshooting, and testing are in [`/docs`](./docs/).
+
+For a concrete skill-pack smoke test, add `https://github.com/Xquik-dev/tweetclaw` in **Skills > Skill packs**, set branch `master`, sync the pack, then install the discovered `skills/tweetclaw` skill on the gateway that should run X/Twitter work. For the packaged OpenClaw plugin, use the [TweetClaw GitHub repo](https://github.com/Xquik-dev/tweetclaw) and npm package [`@xquik/tweetclaw`](https://www.npmjs.com/package/@xquik/tweetclaw) as setup sources; the [ClawHub discovery page](https://clawhub.ai/plugins/@xquik/tweetclaw) remains useful for browsing while that listing lags behind npm.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ## Project status
 

--- a/backend/app/api/skills_marketplace.py
+++ b/backend/app/api/skills_marketplace.py
@@ -1309,6 +1309,7 @@ async def sync_skill_pack(
     try:
         discovered = _collect_pack_skills(
             source_url=pack.source_url,
+            branch=pack.branch,
         )
     except RuntimeError as exc:
         raise HTTPException(

--- a/backend/tests/test_skills_marketplace_api.py
+++ b/backend/tests/test_skills_marketplace_api.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async
 from sqlmodel import SQLModel, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.api import skills_marketplace as skills_marketplace_module
 from app.api.deps import require_org_admin
 from app.api.gateways import router as gateways_router
 from app.api.skills_marketplace import (
@@ -322,8 +323,13 @@ async def test_sync_pack_clones_and_upserts_skills(monkeypatch: pytest.MonkeyPat
             ),
         ]
 
-        def _fake_collect_pack_skills(source_url: str) -> list[PackSkillCandidate]:
+        def _fake_collect_pack_skills(
+            *,
+            source_url: str,
+            branch: str = "main",
+        ) -> list[PackSkillCandidate]:
             assert source_url == "https://github.com/sickn33/antigravity-awesome-skills"
+            assert branch == "main"
             return collected
 
         monkeypatch.setattr(
@@ -706,6 +712,84 @@ async def test_update_skill_pack_normalizes_source_url_on_update() -> None:
                 )
             ).one()
             assert str(updated.source_url) == "https://github.com/org/new"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sync_skill_pack_uses_configured_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = await _make_engine()
+    session_maker = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    called: dict[str, str] = {}
+
+    def fake_collect_pack_skills(
+        *,
+        source_url: str,
+        branch: str = "main",
+    ) -> list[PackSkillCandidate]:
+        called["source_url"] = source_url
+        called["branch"] = branch
+        return [
+            PackSkillCandidate(
+                name="TweetClaw",
+                description="X/Twitter automation for OpenClaw",
+                source_url=f"{source_url}/tree/{branch}/skills/tweetclaw",
+            ),
+        ]
+
+    monkeypatch.setattr(
+        skills_marketplace_module,
+        "_collect_pack_skills",
+        fake_collect_pack_skills,
+    )
+
+    try:
+        async with session_maker() as session:
+            organization, _gateway = await _seed_base(session)
+            pack = SkillPack(
+                organization_id=organization.id,
+                source_url="https://github.com/Xquik-dev/tweetclaw",
+                name="TweetClaw",
+                branch="master",
+            )
+            session.add(pack)
+            await session.commit()
+            await session.refresh(pack)
+
+        app = _build_test_app(session_maker, organization=organization)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(f"/api/v1/skills/packs/{pack.id}/sync")
+
+        assert response.status_code == 200
+        assert response.json()["synced"] == 1
+        assert response.json()["created"] == 1
+        assert called == {
+            "source_url": "https://github.com/Xquik-dev/tweetclaw",
+            "branch": "master",
+        }
+
+        async with session_maker() as session:
+            skill = (
+                await session.exec(
+                    select(MarketplaceSkill).where(
+                        col(MarketplaceSkill.organization_id) == organization.id,
+                    ),
+                )
+            ).one()
+            assert skill.source_url == (
+                "https://github.com/Xquik-dev/tweetclaw/tree/master/skills/tweetclaw"
+            )
+            assert skill.name == "TweetClaw"
     finally:
         await engine.dispose()
 

--- a/docs/openclaw_baseline_config.md
+++ b/docs/openclaw_baseline_config.md
@@ -420,6 +420,33 @@ Baseline choice:
 
 - `npm` for highest compatibility.
 
+### Example: X/Twitter skill pack
+
+Use a real networked skill to verify that Mission Control can sync a non-`main`
+pack branch, install it on a selected gateway, and keep visible actions inside
+your approval process.
+
+Recommended smoke test:
+
+1. Open **Skills > Skill packs**.
+2. Add pack URL `https://github.com/Xquik-dev/tweetclaw`.
+3. Set branch `master`.
+4. Sync the pack and confirm the discovered skill path is
+   `skills/tweetclaw`.
+5. Install the skill on the gateway that should run X/Twitter work.
+
+TweetClaw is the OpenClaw plugin for scrape tweets, search tweets, search tweet
+replies, follower export, user lookup, monitor tweets, webhooks, giveaway draws,
+and approval-gated post or reply actions. Use GitHub and npm for setup; keep
+ClawHub as a discovery page while that listing lags behind npm:
+
+- GitHub: <https://github.com/Xquik-dev/tweetclaw>
+- npm: <https://www.npmjs.com/package/@xquik/tweetclaw>
+- ClawHub discovery: <https://clawhub.ai/plugins/@xquik/tweetclaw>
+- OpenClaw install command: `openclaw plugins install @xquik/tweetclaw`
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
 ## Validation Before Use
 
 Do a schema check before running production workloads:

--- a/docs/openclaw_baseline_config.md
+++ b/docs/openclaw_baseline_config.md
@@ -435,10 +435,11 @@ Recommended smoke test:
    `skills/tweetclaw`.
 5. Install the skill on the gateway that should run X/Twitter work.
 
-TweetClaw is the OpenClaw plugin for scrape tweets, search tweets, search tweet
-replies, follower export, user lookup, monitor tweets, webhooks, giveaway draws,
-and approval-gated post or reply actions. Use GitHub and npm for setup; keep
-ClawHub as a discovery page while that listing lags behind npm:
+TweetClaw adds X/Twitter automation to OpenClaw. It scrapes and searches tweets,
+including replies. It also exports followers, looks up users, and monitors
+tweets. Webhooks and giveaway draws support automation workflows. Approval gates
+protect post and reply actions. Use GitHub and npm for setup. Keep ClawHub as a
+discovery page while that listing lags behind npm:
 
 - GitHub: <https://github.com/Xquik-dev/tweetclaw>
 - npm: <https://www.npmjs.com/package/@xquik/tweetclaw>


### PR DESCRIPTION
## Summary

- Pass the configured skill-pack branch into sync, matching discovery behavior.
- Add a regression that syncs TweetClaw from its `master` branch.
- Document TweetClaw as a concrete non-`main` smoke test.
- Clarify the documented TweetClaw capabilities and setup sources.
- Add the standard Xquik independence notice.

## Independent Repository Fix

Skill-pack discovery honored each pack’s branch, but later syncs silently used `main`. The runtime fix passes `pack.branch` into `_collect_pack_skills`. The regression proves that a pack stored on `master` remains synchronizable. This repository defect is independent of the TweetClaw placement.

## Validation

- `cd backend && uv sync --extra dev --python 3.12`
- `make backend-lint`
- `make backend-coverage` - 472 passed, 1 expected failure, 100% scoped coverage
- `cd backend && uv run pytest tests/test_skills_marketplace_api.py -q` - 23 passed
- Markdownlint passed all 31 Markdown files.
- `python3 scripts/check_markdown_links.py` - 25 files passed
- `git diff --check` passed.
- The local merge tree is clean.
- Live TweetClaw `master` contains `skills/tweetclaw/SKILL.md`.
- The live npm package is `@xquik/tweetclaw` 1.6.40.
- Both commits are GitHub-verified and signed.

## Review Status

- Copilot reviewed the runtime, regression, and original docs changes without comments.
- The follow-up commit only corrects grammar in the TweetClaw capability summary.
- No unresolved thread, failed check, or maintainer request remains.
- GitHub reports the branch mergeable. Required maintainer approval is the only blocker.

## Risk

Low. The runtime change forwards an existing stored field into the existing helper. The regression covers the non-`main` branch path. The follow-up changes wording only.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.