### PR TITLE
fix: protocol mismatch error on Create Gateway 

### DIFF
--- a/backend/app/services/openclaw/gateway_rpc.py
+++ b/backend/app/services/openclaw/gateway_rpc.py
@@ -28,7 +28,7 @@ from app.services.openclaw.device_identity import (
     sign_device_payload,
 )
 
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 # Resolved once at import time; matches the value written by the openclaw CLI
 # during pairing ("linux", "darwin", or "windows").
 _HOST_PLATFORM: str = _platform.system().lower()


### PR DESCRIPTION
## Task / context
- Mission Control task: https://github.com/abhi1693/openclaw-mission-control/issues/353
- Why: Updates the protocol version from 3 to 4

## Scope
- gateway_rpc.py

### Out of scope
- <explicitly list what is NOT included>

## Evidence / validation
- [ ] `make check` (or explain what you ran instead)
- [ ] E2E (if applicable): <cypress run / screenshots>
- Logs/links:
  - <link to CI run>

## Screenshots (UI changes)
| Desktop | Mobile |
| --- | --- |
| <img src="..." width="600" /> | <img src="..." width="300" /> |

## Docs impact
- N/A

## Risk / rollout notes
- Risk level: low
- Rollback plan (if needed): change back to version 3

## Checklist
- [x ] Branch created from `origin/master` (no unrelated commits)
- [x] PR is focused (one theme)
- [x] No secrets in code/logs/docs
- [ ] If API/behavior changes: docs updated (OpenAPI + `docs/reference/api.md`)
